### PR TITLE
docs: Fix faulty links on "Install Nuxt SEO"

### DIFF
--- a/docs/content/0.nuxt-seo/1.getting-started/1.installation.md
+++ b/docs/content/0.nuxt-seo/1.getting-started/1.installation.md
@@ -50,7 +50,7 @@ export default defineNuxtConfig({
 
 Many of the Nuxt SEO modules will need to know what your production canonical URL is to avoid issues.
 
-You can learn to set one by reading the [Recommended Site Config](/site-config/guide/setting-site-config) guide.
+You can learn to set one by reading the [Recommended Site Config](/nuxt-seo/guides/configuring-modules) guide.
 
 ## Staging / Testing Environments
 
@@ -67,5 +67,5 @@ If you only have a production environment, you can skip this step.
 All modules are now installed and configured!
 
 - Have dynamic URLs? Learn how to [configure dynamic URLs](/sitemap/guides/dynamic-urls) for your sitemap.
-- Want to set up dynamic OG Images? Follow the [Tutorial: Getting Familiar With Nuxt OG Image](/og-image/getting-started/getting-familiar-with-nuxt-og-image).
+- Want to set up dynamic OG Images? Follow the [Tutorial: Getting Familiar With Nuxt OG Image](/og-image/getting-started/getting-familar-with-nuxt-og-image).
 - Want to get started with Schema.org quickly? Check the [Schema.org Quick Start](/schema-org/guides/quick-setup) guide.


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
This MR is fixing some faulty links on the get started page. IMO the final solution would be to also fix the typo in the url (`getting-familar-with-nuxt-og-image` to `getting-familiar-with-nuxt-og-image` - famil**i**ar).