### PR TITLE
docs(runtime-site-config): add missing event parameter

### DIFF
--- a/docs/content/10.site-config/2.guides/3.runtime-site-config.md
+++ b/docs/content/10.site-config/2.guides/3.runtime-site-config.md
@@ -44,10 +44,11 @@ If you prefer a simpler API, you can a Nitro middleware instead with `updateSite
 For example, here we are setting site config based on an admin host:
 
 ```ts [server/middleware/update-site-config.ts]
-export default defineRequestMiddleware(async (e) => {
-  const host = useNitroOrigin(e)
+export default defineRequestMiddleware(async (event) => {
+  const host = useNitroOrigin(event)
+
   if (host.startsWith('admin.')) {
-    updateSiteConfig({
+    updateSiteConfig(event, {
       name: 'Admin',
       indexable: false,
       url: 'https://admin.example.com'


### PR DESCRIPTION
### Description

`updateSiteConfig` should require `event` as first parameter. I also made it a bit more clear what `e` is and separated the if block from the assignment for (subjectively) better readability.

### Linked Issues

n/a

### Additional context

n/a
