### PR TITLE
docs: skipped word in documentation

### DIFF
--- a/docs/content/10.site-config/4.api/1.update-site-config.md
+++ b/docs/content/10.site-config/4.api/1.update-site-config.md
@@ -7,7 +7,7 @@ Modify the site config at runtime. You can provide any config to this function, 
 
 :u-badge{label="Warning" color="amber"}
 
-When using this, you will to run it as early as possible in the Nuxt lifecycle to avoid conflicts with other modules.
+When using this, you will have to run it as early as possible in the Nuxt lifecycle to avoid conflicts with other modules.
 It's recommended to use the Nitro [updateSiteConfig](/site-config/nitro-api/update-site-config) API instead.
 
 ## Usage

--- a/docs/content/10.site-config/4.nitro-api/1.update-site-config.md
+++ b/docs/content/10.site-config/4.nitro-api/1.update-site-config.md
@@ -7,7 +7,7 @@ Same as [updateSiteConfig](/site-config/api/update-site-config) but you will nee
 
 :u-badge{label="Warning" color="amber"}
 
-When using this, you will to run it as early as possible within the request lifecycle to avoid conflicts. It's
+When using this, you will have to run it as early as possible within the request lifecycle to avoid conflicts. It's
 recommended to run this either in a Nitro plugin or a nitro middleware.
 
 ## Usage


### PR DESCRIPTION
### Description

Added a word that's been accidentally skipped in documentation
