### PR TITLE
fix: useBreadcrumbItems() server error

### DIFF
--- a/src/runtime/nuxt/composables/useBreadcrumbItems.ts
+++ b/src/runtime/nuxt/composables/useBreadcrumbItems.ts
@@ -189,13 +189,13 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
   if (process.server && schemaOrgEnabled) {
     useSchemaOrg([
       defineBreadcrumb({
-        id: `#${options.id || "breadcrumb"}`,
-        itemListElement: items.value.map((item) => ({
+        id: `#${options.id || 'breadcrumb'}`,
+        itemListElement: items.value.map(item => ({
           name: item.label || item.ariaLabel,
-          item: item.to
-        }))
-      })
-    ]);
+          item: item.to,
+        })),
+      }),
+    ])
   }
   return items
 }

--- a/src/runtime/nuxt/composables/useBreadcrumbItems.ts
+++ b/src/runtime/nuxt/composables/useBreadcrumbItems.ts
@@ -188,16 +188,14 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
   const schemaOrgEnabled = typeof options.schemaOrg === 'undefined' ? true : options.schemaOrg
   if (process.server && schemaOrgEnabled) {
     useSchemaOrg([
-      defineBreadcrumb(computed(() => {
-        return {
-          id: `#${options.id || 'breadcrumb'}`,
-          itemListElement: items.value.map(item => ({
-            name: item.label || item.ariaLabel,
-            item: item.to,
-          })),
-        }
-      })),
-    ])
+      defineBreadcrumb({
+        id: `#${options.id || "breadcrumb"}`,
+        itemListElement: items.value.map((item) => ({
+          name: item.label || item.ariaLabel,
+          item: item.to
+        }))
+      })
+    ]);
   }
   return items
 }


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Server falls with 500 error when using useBreadcrumbItems() composable. Fixed it in PR.
![error500](https://github.com/harlan-zw/nuxt-seo/assets/147421571/f8921740-500e-44b3-a6a4-a8561cd18061)

The problem occurs if use the useBreadcrumbItems() in script setup for something but do not use it in the template. For example, this code will cause an error on the server but it shouldn't

```vue
<template>
  <div>My content...</div>
</template>

<script setup lang="ts">
definePageMeta({
  title: "Some title",
});

const links = useBreadcrumbItems();
console.log(links.value);

// Something use
// useMyComposable(links);
// Or
// Compute something with links
// const myLinks = computed(() =>
//   links.value.map((item) => {
//     return { label: item.label, to: item.to };
//   }),
// );
// console.log(myLinks.value);
</script>
```
I think one of the problems is using utility functions like withSiteTrailingSlash() in the computed function that contain composables like useSiteConfig() and nested computed functions. If I notice something that critically affects the work, I will try to fix it. In general, everything basic works, but in some use cases it requires code optimization. Thanks for great module.
