### PR TITLE
docs: fix link url

### DIFF
--- a/docs/content/3.og-image/0.getting-started/5.getting-familar-with-nuxt-og-image.md
+++ b/docs/content/3.og-image/0.getting-started/5.getting-familar-with-nuxt-og-image.md
@@ -97,7 +97,7 @@ You can find the template source code within the `Community` tab of Nuxt DevTool
 
 ### 1. Create your template component
 
-We're going to start with the [SimpleBlog](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/runtime/components/Templates/Community/SimpleBlog.vue) template as a quick way to get started.
+We're going to start with the [SimpleBlog](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/runtime/nuxt/components/Templates/Community/SimpleBlog.vue) template as a quick way to get started.
 
 Let's copy this template into our project at `./components/OgImage/BlogPost.vue` and remove some of the boilerplate.
 

--- a/docs/content/3.og-image/4.api/2.nuxt-seo-template.md
+++ b/docs/content/3.og-image/4.api/2.nuxt-seo-template.md
@@ -11,7 +11,7 @@ The `NuxtSeo` template is the default one provided for you. It comes with a numb
 to let you customise it however you like.
 
 Like all Community templates, it's recommended to copy+paste it into your project if you want to customise it. You can find
-the source on [GitHub](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/runtime/components/Templates/Community/NuxtSeo.vue).
+the source on [GitHub](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/runtime/nuxt/components/Templates/Community/NuxtSeo.vue).
 
 ## Props
 


### PR DESCRIPTION
### Description

The previous link was invalid, causing a 404 - page not found, and I thought a quick fix was needed.
