### PR TITLE
doc: fixed GitHub Templates/Community URL

### DIFF
--- a/docs/content/3.og-image/0.getting-started/5.getting-familar-with-nuxt-og-image.md
+++ b/docs/content/3.og-image/0.getting-started/5.getting-familar-with-nuxt-og-image.md
@@ -93,11 +93,11 @@ they will always be limited in what you can with them.
 
 For this reason it's recommended to copy+paste the template you want to use into your project and customize it from there.
 
-You can find the template source code within the `Community` tab of Nuxt DevTools or on [GitHub](https://github.com/harlan-zw/nuxt-og-image/tree/main/src/runtime/components/Templates/Community).
+You can find the template source code within the `Community` tab of Nuxt DevTools or on [GitHub](https://github.com/nuxt-modules/og-image/tree/main/src/runtime/nuxt/components/Templates/Community).
 
 ### 1. Create your template component
 
-We're going to start with the [SimpleBlog](https://github.com/harlan-zw/nuxt-og-image/blob/main/src/runtime/nuxt/components/Templates/Community/SimpleBlog.vue) template as a quick way to get started.
+We're going to start with the [SimpleBlog](https://github.com/nuxt-modules/og-image/tree/main/src/runtime/nuxt/components/Templates/Community/SimpleBlog.vue) template as a quick way to get started.
 
 Let's copy this template into our project at `./components/OgImage/BlogPost.vue` and remove some of the boilerplate.
 


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Fixed the links leading to a 404 page when trying to visit the templates in [OG-Image Tutorial: Part 3](https://nuxtseo.com/og-image/getting-started/getting-familar-with-nuxt-og-image#part-3-creating-your-own-template)
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
replaced 
`https://github.com/harlan-zw/nuxt-og-image/...`
with
`https://github.com/nuxt-modules/og-image/...`
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
