### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/docs/components/docs/DocsTocLinks.vue
+++ b/docs/components/docs/DocsTocLinks.vue
@@ -16,7 +16,7 @@ const { activeHeadings, updateHeadings } = useScrollspy()
 
 watch(() => route.path, () => {
   setTimeout(() => {
-    if (process.client) {
+    if (import.meta.client) {
       updateHeadings([
         ...document.querySelectorAll('h2'),
         ...document.querySelectorAll('h3'),

--- a/src/runtime/nuxt/composables/useBreadcrumbItems.ts
+++ b/src/runtime/nuxt/composables/useBreadcrumbItems.ts
@@ -191,7 +191,7 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
   })
 
   const schemaOrgEnabled = typeof options.schemaOrg === 'undefined' ? true : options.schemaOrg
-  if (process.server && schemaOrgEnabled) {
+  if (import.meta.server && schemaOrgEnabled) {
     useSchemaOrg([
       defineBreadcrumb(computed(() => {
         return {


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
