### PR TITLE
doc: typo

### DIFF
--- a/docs/content/6.link-checker/4.api/0.config.md
+++ b/docs/content/6.link-checker/4.api/0.config.md
@@ -1,6 +1,6 @@
 ---
 title: Config
-description: Configure the sitemap module.
+description: Configure the link checker module.
 ---
 
 ## `enabled`


### PR DESCRIPTION
### Description

Fixing copy paste error on link checker documentation

