### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,6 @@ With powerful APIs built for fully dynamic sites and zero-config defaults for st
 npx nuxi@latest module add seo
 ```
 
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config]
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/seo']
-})
-```
-
 That's it!
 
 All features are enabled by default. Learn more by exploring the [documentation](https://nuxtseo.com)

--- a/docs/content/0.nuxt-seo/1.getting-started/1.installation.md
+++ b/docs/content/0.nuxt-seo/1.getting-started/1.installation.md
@@ -8,16 +8,9 @@ navigation:
 ## Setup
 
 1. Install `@nuxtjs/seo` dependency to your project:
+
 ```bash
 npx nuxi@latest module add seo
-```
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/seo']
-})
 ```
 
 ## Site URL

--- a/docs/content/1.robots/1.getting-started/0.installation.md
+++ b/docs/content/1.robots/1.getting-started/0.installation.md
@@ -11,28 +11,8 @@ Using [Nuxt SEO](/nuxt-seo/getting-started/installation)? This module is already
 
 1. Install `nuxt-simple-robots` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D nuxt-simple-robots
-```
-
-```bash [yarn]
-yarn add -D nuxt-simple-robots
-```
-
-```bash [npm]
-npm install -D nuxt-simple-robots
-```
-
-::
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-simple-robots']
-})
+```bash
+npx nuxi@latest module add simple-robots
 ```
 
 ## Staging / Testing Environments

--- a/docs/content/2.sitemap/0.getting-started/1.installation.md
+++ b/docs/content/2.sitemap/0.getting-started/1.installation.md
@@ -7,31 +7,11 @@ navigation:
 
 1. Install `@nuxtjs/sitemap` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D @nuxtjs/sitemap
+```bash
+npx nuxi@latest module add sitemap
 ```
 
-```bash [yarn]
-yarn add -D @nuxtjs/sitemap
-```
-
-```bash [npm]
-npm install -D @nuxtjs/sitemap
-```
-
-::
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['@nuxtjs/sitemap']
-})
-```
-
-3. Set Site Config
+2. Set Site Config
 
 It's recommended to always set a canonical site URL to avoid duplicate content issues.
 
@@ -62,13 +42,13 @@ export default defineNuxtConfig({
 })
 ```
 
-4. Preview your Sitemap
+3. Preview your Sitemap
 
 After you've set up the module, if you visit `/sitemap.xml` you can see the generated sitemap.
 
 This has been generated with [Application Sources](/sitemap/getting-started/data-sources).
 
-5. Next Steps
+4. Next Steps
 
 - You may want to add your own sources, see [Dynamic URLs](/sitemap/guides/dynamic-urls).
 - Have 1000's of pages? Consider using [Multiple Sitemaps](/sitemap/guides/multi-sitemaps).

--- a/docs/content/3.og-image/0.getting-started/1.installation.md
+++ b/docs/content/3.og-image/0.getting-started/1.installation.md
@@ -9,31 +9,11 @@ Using [Nuxt SEO](/nuxt-seo/getting-started/installation)? This module is already
 
 1. Install the `nuxt-og-image` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D nuxt-og-image
+```bash
+npx nuxi@latest module add og-image
 ```
 
-```bash [yarn]
-yarn add -D nuxt-og-image
-```
-
-```bash [npm]
-npm install -D nuxt-og-image
-```
-
-::
-
-2. Add `nuxt-og-image` to `modules` in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-og-image']
-})
-```
-
-3. Set a Site URL
+2. Set a Site URL
 
 To prerender pages that use OG Image, the module needs to know your site URL.
 
@@ -56,7 +36,7 @@ NUXT_PUBLIC_SITE_URL=https://example.com
 
 For more complex applications, learn more at the [Nuxt Site Config docs](/site-config/getting-started/how-it-works).
 
-4. Enable Nuxt DevTools
+3. Enable Nuxt DevTools
 
 Nuxt OG Image uses [Nuxt DevTools](https://devtools.nuxt.com/) to provide a live preview of your OG Images.
 

--- a/docs/content/4.schema-org/0.getting-started/1.installation.md
+++ b/docs/content/4.schema-org/0.getting-started/1.installation.md
@@ -15,31 +15,11 @@ Ensure you haven't disabled SSR using `ssr: false` in your `nuxt.config`.
 
 1. Install `nuxt-schema-org` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D nuxt-schema-org
+```bash
+npx nuxi@latest module add schema-org
 ```
 
-```bash [yarn]
-yarn add -D nuxt-schema-org
-```
-
-```bash [npm]
-npm install -D nuxt-schema-org
-```
-
-::
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-schema-org']
-})
-```
-
-3. Configure your site details.
+2. Configure your site details.
 
 It's recommended to set a canonical site URL to avoid duplicate content issues, as well as a site name
 for better default configuration.

--- a/docs/content/6.link-checker/0.getting-started/1.installation.md
+++ b/docs/content/6.link-checker/0.getting-started/1.installation.md
@@ -7,28 +7,8 @@ navigation:
 
 1. Install `nuxt-link-checker` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D nuxt-link-checker
-```
-
-```bash [yarn]
-yarn add -D nuxt-link-checker
-```
-
-```bash [npm]
-npm install -D nuxt-link-checker
-```
-
-::
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-link-checker']
-})
+```bash
+npx nuxi@latest module add link-checker
 ```
 
 That's it! Explore the documentation to learn more.

--- a/docs/content/7.experiments/0.getting-started/1.installation.md
+++ b/docs/content/7.experiments/0.getting-started/1.installation.md
@@ -7,31 +7,11 @@ navigation:
 
 1. Install `nuxt-seo-experiments` dependency to your project:
 
-::code-group
-
-```sh [pnpm]
-pnpm i -D nuxt-seo-experiments
+```bash
+npx nuxi@latest module add seo-experiments
 ```
 
-```bash [yarn]
-yarn add -D nuxt-seo-experiments
-```
-
-```bash [npm]
-npm install -D nuxt-seo-experiments
-```
-
-::
-
-2. Add it to your `modules` section in your `nuxt.config`:
-
-```ts [nuxt.config.ts]
-export default defineNuxtConfig({
-  modules: ['nuxt-seo-experiments']
-})
-```
-
-3. Set a Site URL
+2. Set a Site URL
 
 To ensure links are set up correctly, the module needs to know your site URL.
 


### PR DESCRIPTION
### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

`nuxi module add` section has been added for `Nuxt SEO` in the #216 issue.
For documentation uniformity, the following modules also have sections added

- `simple-robots`
- `sitemap`
- `og-image`
- `schema-org`
- `link-checker`
- `seo-experiments`

`site-config` is not supported because the module was not yet added.
The documentation would like to addressed after the module is added.

- related: harlan-zw/nuxt-site-config#30

### Linked Issues

related #216 , harlan-zw/nuxt-site-config#30

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
