### PR TITLE
fix typo

### DIFF
--- a/docs/components/content/examples/BreadcrumbNuxtUiExample.vue
+++ b/docs/components/content/examples/BreadcrumbNuxtUiExample.vue
@@ -30,7 +30,7 @@ const items = useBreadcrumbItems({ path, hideRoot, hideCurrent })
           <label>Hide Root
             <UToggle v-model="hideRoot" />
           </label>
-          <label>Hiden Current
+          <label>Hide Current
             <UToggle v-model="hideCurrent" label="Hide Current" />
           </label>
         </div>


### PR DESCRIPTION
### Description

Fixes a small typo in [useBreadcrumbItems() · Nuxt SEO](https://nuxtseo.com/nuxt-seo/api/breadcrumbs): "Hiden Current" => "Hide Current".