### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/2.sitemap/0.getting-started/4.faq.md
+++ b/docs/content/2.sitemap/0.getting-started/4.faq.md
@@ -20,5 +20,5 @@ There is no workaround besides re-enabled the XSL.
 Seeing "Error" when submitting a new sitemap is common. This is because Google previously
 crawled your site for a sitemap and found nothing.
 
-If you're sitemap is [validating](https://www.xml-sitemaps.com/validate-xml-sitemap.html) correctly, then you're all set.
+If your sitemap is [validating](https://www.xml-sitemaps.com/validate-xml-sitemap.html) correctly, then you're all set.
 It's best to way a few days and check back. In nearly all cases, the error will resolve itself.


### PR DESCRIPTION
### Description
Fixes typo. The previous "If _you're_ sitemap is validating…" expands to "If _you are_ sitemap is validating", which doesn't make sense. It's likely the intended start of the sentence is "If _your_ sitemap is validating…".

