### PR TITLE
doc: broken breadcrumbs snippet

### DIFF
--- a/docs/content/0.nuxt-seo/3.api/_breadcrumb-raw.md
+++ b/docs/content/0.nuxt-seo/3.api/_breadcrumb-raw.md
@@ -6,9 +6,9 @@ const links = useBreadcrumbItems() // uses the current route
 <template>
   <nav aria-label="Breadcrumbs">
     <ul>
-      <li v-for="(item, key) in items" :key="key">
-        <NuxtLink v-bind="item">
-          {{ item.label }}
+      <li v-for="(link, key) in links" :key="key">
+        <NuxtLink v-bind="link">
+          {{ link.label }}
         </NuxtLink>
       </li>
     </ul>


### PR DESCRIPTION
### Description

When copy pasting the example code it will give a 500 server error since the variables do not match

### Linked Issues


### Additional context

