### PR TITLE
docs: fix spelling

### DIFF
--- a/docs/content/0.nuxt-seo/2.guides/0.using-the-modules.md
+++ b/docs/content/0.nuxt-seo/2.guides/0.using-the-modules.md
@@ -57,7 +57,7 @@ Checks all links for issues that may be affecting your SEO.
 
 A few extra SEO Nuxt features that don't fit anywhere else.
 
-- See the [SEO Expereriments Features](/experiments/getting-started/features) guide for more information.
+- See the [SEO Experiments Features](/experiments/getting-started/features) guide for more information.
 - Automatic File Metadata [Icons](/experiments/guides/app-icons) and [Open Graph Images](/experiments/guides/open-graph-images)
 - Opt in [seoMeta](/experiments/guides/nuxt-config-seo-meta) in your nuxt.config and route rules
 

--- a/docs/content/0.nuxt-seo/2.guides/2.title-templates.md
+++ b/docs/content/0.nuxt-seo/2.guides/2.title-templates.md
@@ -19,8 +19,8 @@ The following tokens are available out-of-the-box:
 - `%siteName` - The name of your site.
 - `%siteUrl` - The canonical URL of your site.
 - `%s` or `%pageTitle` - The page title, without the template
-- `%separator` - Special token used to seperate parts of your title. These have special behavior in that
-they will be logically removed when it makes sense. See [Seperator](https://unhead.unjs.io/usage/guides/template-params) for more details.
+- `%separator` - Special token used to separate parts of your title. These have special behaviour in that
+they will be logically removed when it makes sense. See [Separator](https://unhead.unjs.io/usage/guides/template-params#separator) for more details.
 
 These tokens are available not only for the title, but also:
 - `meta: [ { content: '%site.url/my-url.png' } ]`

--- a/docs/content/0.nuxt-seo/2.guides/3.trailing-slashes.md
+++ b/docs/content/0.nuxt-seo/2.guides/3.trailing-slashes.md
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
 
 ## Handling Internal Links
 
-While Nuxt SEO can handle the correct trailing slashes for all of its own modules, it can't correct the behavior of
+While Nuxt SEO can handle the correct trailing slashes for all of its own modules, it can't correct the behaviour of
 `<NuxtLink>` or other modules.
 
 You will need to make sure you're using the correct slashes for these.

--- a/docs/content/0.nuxt-seo/6.migration-guide/0.nuxt-seo-kit.md
+++ b/docs/content/0.nuxt-seo/6.migration-guide/0.nuxt-seo-kit.md
@@ -109,7 +109,7 @@ When updating your config:
 - All keys are without the `site` prefix
 - The `language` config has been renamed to `defaultLocale`
 
-The behavior for environment variables hasn't changed, it's recommended to read [how site config works](/site-config/getting-started/how-it-works) for
+The behaviour for environment variables hasn't changed, it's recommended to read [how site config works](/site-config/getting-started/how-it-works) for
 more advanced configuration.
 
 ## Prerendering Changes
@@ -182,7 +182,7 @@ If you were referencing the old default template, you will need to update it.
 
 Composables & Components:
 
-- `defineOgImageStatic()` is deprecated, use `defineOgImage()` (default behavior is to cache), if you want to be verbose you can use `defineOgImageCached()` or `<OgImageCached />`
+- `defineOgImageStatic()` is deprecated, use `defineOgImage()` (default behaviour is to cache), if you want to be verbose you can use `defineOgImageCached()` or `<OgImageCached />`
 -  `<OgImageStatic />` is deprecated, use `<OgImage />`
 - `defineOgImageDynamic()` is deprecated, use `defineOgImageWithoutCache()`
 - `<OgImageDynamic />` is deprecated, use `<OgImageWithoutCache />`

--- a/docs/content/1.robots/1.getting-started/how-it-works.md
+++ b/docs/content/1.robots/1.getting-started/how-it-works.md
@@ -6,7 +6,7 @@ description: Learn more about how Nuxt Simple Robots works.
 Nuxt Robots tells robots (crawlers) how to behave by creating a `robots.txt` file for you, adding a `X-Robots-Tag` header and `<meta name="robots">` tag to your site
 where appropriate.
 
-One important behavior to control is blocking Google from indexing pages to:
+One important behaviour to control is blocking Google from indexing pages to:
 - Prevent [duplicate content issues](https://moz.com/learn/seo/duplicate-content)
 - Prevent wasting [crawl budget](https://developers.google.com/search/docs/crawling-indexing/large-site-managing-crawl-budget)
 

--- a/docs/content/1.robots/3.nitro-api/2.nitro-hooks.md
+++ b/docs/content/1.robots/3.nitro-api/2.nitro-hooks.md
@@ -35,7 +35,7 @@ export default defineNitroPlugin((nitroApp) => {
 **Type:**
 
 ```ts
-interface HookContexct {
+interface HookContext {
   e: H3Event
   robotsTxt: string
 }

--- a/docs/content/1.robots/4.releases/1.v4.md
+++ b/docs/content/1.robots/4.releases/1.v4.md
@@ -128,7 +128,7 @@ You should remove this from your code.
 
 ### `index` Route Rule
 
-The `index` route rule has been deprecated in favor of the `robots` rule. This provides
+The `index` route rule has been deprecated in favour of the `robots` rule. This provides
 less ambiguity and more control over the rule.
 
 ```diff

--- a/docs/content/10.site-config/0.getting-started/0.background.md
+++ b/docs/content/10.site-config/0.getting-started/0.background.md
@@ -5,7 +5,7 @@ description: Learn about the motivation behind Nuxt Site Config and a bit about 
 
 Site config aims to be to things:
 - A single source of truth for site config, for end-users and module authors. Site config can be considered config that is commonly used amongst modules but is not supported by the Nuxt core.
-- A set of APIs for working with "writable runtime config", for end-users and module authors.
+- A set of APIs for working with "writeable runtime config", for end-users and module authors.
 
 ## Site Config Examples
 

--- a/docs/content/10.site-config/4.api/0.site-link.md
+++ b/docs/content/10.site-config/4.api/0.site-link.md
@@ -44,7 +44,7 @@ The non-canonical URL will use the request origin instead of the configured site
 
 ## Component Options
 
-If needed, you can modify the behavior of how this component is registered through using Nuxt Config.
+If needed, you can modify the behaviour of how this component is registered through using Nuxt Config.
 
 This can be useful for making the component global, allowing it to work in Nuxt Content, or setting a prefix
 to avoid collisions with other components.

--- a/docs/content/10.site-config/4.api/config.md
+++ b/docs/content/10.site-config/4.api/config.md
@@ -22,7 +22,7 @@ Whether the debug mode of the site config is enabled.
 - Type: `object`
 - Default: `{}`
 
-Modify the behavior of how the [&lt;SiteLink&gt;](/site-config/api/site-link) is registered.
+Modify the behaviour of how the [&lt;SiteLink&gt;](/site-config/api/site-link) is registered.
 
 ```ts
 export default defineNuxtConfig({

--- a/docs/content/10.site-config/4.nitro-api/3.get-site-indexable.md
+++ b/docs/content/10.site-config/4.nitro-api/3.get-site-indexable.md
@@ -7,7 +7,7 @@ Determine if the site is indexable by search engines.
 
 This will use the `env`, if it is `production` then it will return `true`, otherwise it will return `false`.
 
-It can be overriden by providing a `indexable` property in the site config. This allows you to
+It can be overridden by providing a `indexable` property in the site config. This allows you to
 opt-out of indexing in production.
 
 ## Usage

--- a/docs/content/2.sitemap/0.getting-started/2.data-sources.md
+++ b/docs/content/2.sitemap/0.getting-started/2.data-sources.md
@@ -12,7 +12,7 @@ A source will either be a User source or a Application source.
 Application sources are sources generated automatically from your app. These are in place to make using the module more
 convenient but may get in the way.
 
-- `nuxt:pages` - Statically analyzed pages of your application
+- `nuxt:pages` - Statically analysed pages of your application
 - `nuxt:prerender` - URLs that were prerendered
 - `nuxt:route-rules` - URLs from your route rules
 - `@nuxtjs/i18n:pages` - When using the `pages` config with Nuxt I18n. See [Nuxt I18n](/sitemap/integrations/i18n) for more details.

--- a/docs/content/2.sitemap/1.integrations/1.content.md
+++ b/docs/content/2.sitemap/1.integrations/1.content.md
@@ -24,7 +24,7 @@ export default defineNuxtConfig({
 ```
 
 If you're not using `documentDriven` mode and your content paths are the same as their real paths,
-you can enable `strictNuxtContentPaths` to get the same behavior.
+you can enable `strictNuxtContentPaths` to get the same behaviour.
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/2.sitemap/2.guides/4.route-rules.md
+++ b/docs/content/2.sitemap/2.guides/4.route-rules.md
@@ -3,7 +3,7 @@ title: Route Rules
 description: Configure your sitemap entries with route rules.
 ---
 
-To change the behavior of your sitemap URLs, you can use [Route rules](https://nuxt.com/docs/api/configuration/nuxt-config/#routerules).
+To change the behaviour of your sitemap URLs, you can use [Route rules](https://nuxt.com/docs/api/configuration/nuxt-config/#routerules).
 
 When doing so, you can provide either `robots: false` as a shortcut or a full `sitemap` object, see [Sitemap URL Schema](/sitemap/api/schema).
 

--- a/docs/content/2.sitemap/5.releases/v3.md
+++ b/docs/content/2.sitemap/5.releases/v3.md
@@ -64,7 +64,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Learn more on the [Customing the UI](/sitemap/guides/customising-ui) guide.
+Learn more on the [Customising the UI](/sitemap/guides/customising-ui) guide.
 
 ### Debug Mode
 
@@ -125,7 +125,7 @@ Enable when the paths of your nuxt/content md files match the routing.
 
 This will automatically add sitemap content to the sitemap.
 
-This is similar behavior to using `nuxt/content` with `documentDriven: true`.
+This is similar behaviour to using `nuxt/content` with `documentDriven: true`.
 
 ### New Config: `credits`
 

--- a/docs/content/3.og-image/3.guides/3.jpegs.md
+++ b/docs/content/3.og-image/3.guides/3.jpegs.md
@@ -12,7 +12,7 @@ by default as Sharp is a heavy dependency and [compatibility](/og-image/guides/c
 
 If you're prerendering your images or using a Node based environment, you can enable Sharp to render JPEGs.
 
-For Chromium renderering, `jpeg` images are rendered by default.
+For Chromium rendering, `jpeg` images are rendered by default.
 
 ## Setup
 

--- a/docs/content/3.og-image/4.api/2.nuxt-seo-template.md
+++ b/docs/content/3.og-image/4.api/2.nuxt-seo-template.md
@@ -56,7 +56,7 @@ See the [Icons and Images](/og-image/guides/icons-and-images) guide for more inf
 **Type:** `string`
 **Default:** `#00dc82`
 
-Changes the theme of the template. You should either provide a hexidecimal color or a valid rgb.
+Changes the theme of the template. You should either provide a hexadecimal color or a valid rgb.
 
 For example: `#d946ef`
 

--- a/docs/content/3.og-image/4.api/3.config.md
+++ b/docs/content/3.og-image/4.api/3.config.md
@@ -97,7 +97,7 @@ Extra component directories that should be used to resolve components.
 - Default: `true`
 - Required: `false`
 
-Modify the cache behavior.
+Modify the cache behaviour.
 
 Passing a boolean will enable or disable the runtime cache with the default options.
 

--- a/docs/content/3.og-image/4.api/3.nuxt-hooks.md
+++ b/docs/content/3.og-image/4.api/3.nuxt-hooks.md
@@ -1,6 +1,6 @@
 ---
 title: Nuxt Hooks
-description: Hook into the Nuxt OG Image build-time behavior.
+description: Hook into the Nuxt OG Image build-time behaviour.
 ---
 
 Built-time hooks for Nuxt OG Image.

--- a/docs/content/3.og-image/7.releases/v2.md
+++ b/docs/content/3.og-image/7.releases/v2.md
@@ -185,7 +185,7 @@ If you were referencing the old default template, you will need to update it.
 
 Composables & Components:
 
-- `defineOgImageStatic()` is deprecated, use `defineOgImage()` (default behavior is to cache), if you want to be verbose you can use `defineOgImageCached()` or `<OgImageCached />`
+- `defineOgImageStatic()` is deprecated, use `defineOgImage()` (default behaviour is to cache), if you want to be verbose you can use `defineOgImageCached()` or `<OgImageCached />`
 -  `<OgImageStatic />` is deprecated, use `<OgImage />`
 - `defineOgImageDynamic()` is deprecated, use `defineOgImageWithoutCache()`
 - `<OgImageDynamic />` is deprecated, use `<OgImageWithoutCache />`

--- a/docs/content/3.og-image/7.releases/v3.md
+++ b/docs/content/3.og-image/7.releases/v3.md
@@ -22,7 +22,7 @@ well as bespoke hacks:
 - Nuxt Islands
 - Nitro WASM support
 - Binary data with Unstorage and serving it with H3
-- Customining Nitro prerenderer
+- Customising Nitro prerenderer
 
 In rewriting the module, I wanted to opt-in to newer more stable ways of doing things, or send upstream PRs so
 I wouldn't need to rely on hacks.

--- a/docs/content/6.link-checker/4.api/0.config.md
+++ b/docs/content/6.link-checker/4.api/0.config.md
@@ -61,7 +61,7 @@ If set to `true`, the build will fail if any broken links are found.
 
 An array of URLs to exclude from the check.
 
-This can be useful if you have a route that is not pre-rendered, but you know it will be valid.
+This can be useful if you have a route that is not prerendered, but you know it will be valid.
 
 ## `debug`
 

--- a/docs/content/7.experiments/4.releases/v3.md
+++ b/docs/content/7.experiments/4.releases/v3.md
@@ -129,7 +129,7 @@ Version 3.0.0 now avoids setting a default `titleTemplate` for you. You should n
 export default defineNuxtConfig({
   app: {
     head: {
-      titleTemplate: '%s %seperator %siteName'
+      titleTemplate: '%s %separator %siteName'
     }
   }
 })


### PR DESCRIPTION

### Description

Fixed some spelling errors across the docs. 

Some words were adjusted to be consistent with en-GB spelling that looks to be used in the project. e.g. (behavior ->  behaviour, analyze -> analyse)
