### PR TITLE
fix: redirect using url config key

### DIFF
--- a/src/runtime/nitro/middleware/redirect.ts
+++ b/src/runtime/nitro/middleware/redirect.ts
@@ -4,12 +4,12 @@ import { useNitroOrigin, useSiteConfig } from '#imports'
 
 export default defineEventHandler((e) => {
   const siteConfig = useSiteConfig(e)
-  if (siteConfig.site) {
-    const siteConfigHostName = new URL(e.path, siteConfig.site).hostname
+  if (siteConfig.url) {
+    const siteConfigHostName = new URL(e.path, siteConfig.url).hostname
     const origin = useNitroOrigin(e)
     const originHostname = new URL(e.path, origin).hostname
     // if origin doesn't match site, do a redirect
     if (originHostname !== siteConfigHostName)
-      return sendRedirect(e, joinURL(siteConfig.site, e.path), 301)
+      return sendRedirect(e, joinURL(siteConfig.url, e.path), 301)
   }
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR changes the redirect to use the `site.url` config.

According to the docs, [`redirectToCanonicalSiteUrl` redirects to the default canonical url](https://nuxtseo.com/nuxt-seo/guides/redirect-canonical), which is supposed to be [`site.url`](https://nuxtseo.com/nuxt-seo/guides/default-meta#canonical), not `site.site`