### PR TITLE
fix: `og:url` duplicating base url, using `useServerSeoMeta()`

### DIFF
--- a/src/runtime/nuxt/logic/applyDefaults.ts
+++ b/src/runtime/nuxt/logic/applyDefaults.ts
@@ -13,7 +13,7 @@ export function applyDefaults() {
   // get the head instance
   const siteConfig = useSiteConfig()
   const route = useRoute()
-  const resolveUrl = createSitePathResolver({ withBase: true, absolute: true })
+  const resolveUrl = createSitePathResolver({ absolute: true })
   const canonicalUrl = computed<string>(() => resolveUrl(route.path || '/').value || route.path)
 
   const minimalPriority: UseHeadOptions = {
@@ -55,5 +55,5 @@ export function applyDefaults() {
     seoMeta.twitterSite = id
   }
   // TODO server only for some tags
-  useSeoMeta(seoMeta, minimalPriority)
+  useServerSeoMeta(seoMeta, minimalPriority)
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
[`route.path`](https://router.vuejs.org/api/interfaces/RouteLocationNormalizedLoadedGeneric.html#path) already contains the part of base url;
using `useServerSeoMeta()` may save 2 KiB for client: https://github.com/nuxt/nuxt/discussions/18554, or better introduce a config for it.