### PR TITLE
feat: `canonicalQueryWhitelist`

### DIFF
--- a/docs/content/0.nuxt-seo/2.guides/2.default-meta.md
+++ b/docs/content/0.nuxt-seo/2.guides/2.default-meta.md
@@ -6,15 +6,36 @@ description: The default meta tags Nuxt SEO sets for you.
 To ensure your site is SEO friendly, Nuxt SEO sets some default meta tags for you based
 on your [site config](/nuxt-seo/guides/configuring-modules).
 
-## Canonical
+## Canonical URL
 
-Ensuring a canonical URL is set helps avoid [duplicate content issues](https://support.google.com/webmasters/answer/66359?hl=en)
-when you have multiple domains or subdomains pointing to the same content.
+Ensuring a canonical URL is set helps avoid [duplicate content issues](https://support.google.com/webmasters/answer/66359?hl=en).
 
-It can also occur when you have multiple URLs for the same page, such as when you don't redirect
-[trailing slashes](/nuxt-seo/guides/trailing-slashes).
+This can be an issue when you have multiple domains or subdomains pointing to the same content, 
+[trailing slashes](/nuxt-seo/guides/trailing-slashes) and non-trailing slashes showing the same content
+and when you have query parameters that don't change the content.
 
-The canonical will be set based on your site config `url` and the current route.
+The canonical URL is generated from your site config `url`, the current route and the `canonicalQueryWhitelist`.
+
+### canonicalQueryWhitelist
+
+By default, the `canonicalQueryWhitelist` includes a number of common query parameters that will modify the page content:
+
+- `page`
+- `sort`
+- `filter`
+- `search`
+- `q`
+- `query`
+
+You can override this by providing your own list of query parameters that should be included in the canonical URL.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  seo: {
+    canonicalQueryWhitelist: ['myCustomQuery']
+  }
+})
+```
 
 ## I18n
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -27,6 +27,10 @@ export interface ModuleOptions {
    */
   automaticDefaults?: boolean
   /**
+   * When enabled, it will whitelist the query parameters that are allowed in the canonical URL.
+   */
+  canonicalQueryWhitelist?: string[]
+  /**
    * When enabled, it will redirect any request to the canonical domain (site url) using a 301 redirect on non-dev environments.
    *
    * E.g if the site url is 'www.example.com' and the user visits 'example.com',
@@ -104,6 +108,18 @@ export default defineNuxtModule<ModuleOptions>({
 
     for (const module of Modules)
       await installModule(await resolvePath(module))
+
+    nuxt.options.runtimeConfig.public['nuxt-seo'] = {
+      canonicalQueryWhitelist: config.canonicalQueryWhitelist || [
+        'page',
+        'sort',
+        'filter',
+        'search',
+        'q',
+        'category',
+        'tag',
+      ],
+    }
 
     if (config.automaticDefaults) {
       // i18n complicates things, we need to run the server plugin at the right time, client is fine


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
https://github.com/harlan-zw/nuxt-seo/issues/276

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Adds support for having query params in the canonical URL, this is important when using query param pagination or searching.

Default whitelist:

```ts
[
  'page',
  'sort',
  'filter',
  'search',
  'q',
  'category',
  'tag',
],
```


