### PR TITLE
fix: `useBreadcrumbItems` support static meta from dynamic routes

### DIFF
--- a/src/runtime/nuxt/composables/useBreadcrumbItems.ts
+++ b/src/runtime/nuxt/composables/useBreadcrumbItems.ts
@@ -149,7 +149,7 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
       segments.push(...options.append)
     return (segments.filter(Boolean) as BreadcrumbItemProps[])
       .map((item) => {
-        const route = routes.find(r => withoutTrailingSlash(r.path) === withoutTrailingSlash(item.to))
+        const route = router.resolve(item.to)?.matched
         const routeMeta = (route?.meta || {}) as RouteMeta & { title?: string, breadcrumbLabel: string }
         const routeName = route ? String(route.name || route.path) : (item.to === '/' ? 'index' : 'unknown')
         let [name] = routeName.split('___')


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useBreadcrumbItems()` does not work fetch page's meta from dynamic routes (e.g. `/items/[id]`). This proposes to fix that. This still doesn't solve the problem of dynamic labels as `definePageMeta` is a render macro and figuring out how to morph crumps with dynamic attributes is a different topic, but ability to use even static overrides in dynamic routes I think is usefull
