### PR TITLE
fix(breadcrumbs): support computed overrides

### DIFF
--- a/src/runtime/nuxt/composables/useBreadcrumbItems.ts
+++ b/src/runtime/nuxt/composables/useBreadcrumbItems.ts
@@ -55,7 +55,7 @@ export interface BreadcrumbProps {
   /**
    * Override any of the breadcrumb items based on the index.
    */
-  overrides?: (BreadcrumbItemProps | false | undefined)[]
+  overrides?: MaybeRefOrGetter<(BreadcrumbItemProps | false | undefined)[]>
   /**
    * Should the schema.org breadcrumb be generated.
    * @default true
@@ -127,7 +127,7 @@ export function useBreadcrumbItems(options: BreadcrumbProps = {}) {
     }
     const current = withoutQuery(withoutTrailingSlash(toValue(options.path || router.currentRoute.value?.path) || rootNode))
     // apply overrides
-    const overrides = options.overrides || []
+    const overrides = toValue(options.overrides || []);
     const segments = pathBreadcrumbSegments(current, rootNode)
       .map((path, index) => {
         let item = <BreadcrumbItemProps> {


### PR DESCRIPTION
This PR introduces enhancements to the `useBreadcrumbItems` function in order to facilitate the dynamic updating of breadcrumbs, e. g. based on route parameters.

### 🔗 Linked issue

Resolves #327

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Changed the type of `overrides` in `BreadcrumbProps` from an array to `MaybeRefOrGetter<(BreadcrumbItemProps | false | undefined)[]>` to allow for computed values.
- Updated the assignment of `overrides` to use `toValue` for proper reactive handling of the `options.overrides`.
