### PR TITLE
docs: remove duplicate "Props" title

### DIFF
--- a/docs/content/0.nuxt-seo/2.guides/3.trailing-slashes.md
+++ b/docs/content/0.nuxt-seo/2.guides/3.trailing-slashes.md
@@ -40,8 +40,6 @@ Alternatively, you can use the `<SiteLink>` component.
 
 This has the exact same API as `<NuxtLink>` but will provide extra link resolving features.
 
-### Props
-
 ```vue
 <template>
   <!-- Will be set to /about/ if trailingSlash is enabled -->


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This PR removes a diplicate "Props" title in the `<SiteLink>` section.
