### PR TITLE
fix: allow using a higher version of nuxt

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "execa": "^9.5.2",
     "happy-dom": "^17.4.4",
     "nitropack": "^2.11.9",
-    "nuxt": "3.16.2",
+    "nuxt": "^3.16.2",
     "typescript": "^5.8.3",
     "vitest": "^3.1.1"
   },


### PR DESCRIPTION

### 🔗 Linked issue
NA

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt is currently strictly set to `3.16.2`. This does not allow using  nuxt-seo with newer versions, such as `3.17.2`, which is currently the latest.
