### PR TITLE
docs: improve SEO metadata and add tool links

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -37,6 +37,10 @@ export default defineNuxtModule({
 When using Nuxt SEO you are free to use this alias or install the modules individually. The choice is yours as
 all sites are different and have different requirements.
 
+::callout{icon="i-heroicons-wrench" to="/tools"}
+**Debug your SEO** - Use our free [SEO Tools](/tools) to validate meta tags, test robots.txt, debug social cards, and validate structured data.
+::
+
 ## Getting Started
 
 After learning about what Nuxt SEO is, here's what to do next:

--- a/docs/content/1.getting-started/3.troubleshooting.md
+++ b/docs/content/1.getting-started/3.troubleshooting.md
@@ -1,20 +1,17 @@
 ---
 title: "Troubleshooting"
-description: Create minimal reproductions for Nuxt SEO or just experiment with the module.
+description: Learn how to troubleshoot common Nuxt SEO issues and find helpful resources.
 ---
 
-## StackBlitz Playgrounds
+## Debugging Tools
 
-You can use the Nuxt SEO StackBlitz playgrounds for either:
+Use these free tools to diagnose SEO issues:
 
-- Playing around with the module in a sandbox environment
-- Making reproductions for issues (Learn more about [Why Reproductions are Required](https://antfu.me/posts/why-reproductions-are-required))
-
-Reproductions:
-
-- [Basic](https://stackblitz.com/edit/nuxt-starter-gfrej6?file=nuxt.config.ts)
-- [I18n](https://stackblitz.com/edit/nuxt-starter-dh68fjqb?file=nuxt.config.ts)
-- [Nuxt Content](https://stackblitz.com/edit/nuxt-starter-xlkqkcqr?file=nuxt.config.ts)
+- [Meta Tag Checker](/tools/meta-tag-checker) - Validate title and description
+- [Social Share Debugger](/tools/social-share-debugger) - Debug OG images
+- [Robots.txt Generator](/tools/robots-txt-generator) - Test robots rules
+- [Schema.org Validator](/tools/schema-validator) - Validate structured data
+- [XML Sitemap Validator](/tools/xml-sitemap-validator) - Check sitemap structure
 
 Have a question about Nuxt SEO? Check out the frequently asked questions below or
 [Jump in the Discord](https://discord.com/invite/5jDAMswWwX) and ask me directly!

--- a/docs/content/2.guides/2.nuxt-content.md
+++ b/docs/content/2.guides/2.nuxt-content.md
@@ -3,6 +3,10 @@ title: Nuxt Content
 description: Integrating Nuxt SEO with Nuxt Content.
 ---
 
+::callout{icon="i-heroicons-document-text" to="/tools/html-to-markdown"}
+**Migrating content?** Use our [HTML to Markdown Converter](/tools/html-to-markdown) to convert existing pages to Nuxt Content format.
+::
+
 ## Introduction
 
 Most Nuxt SEO modules integrates with Nuxt Content out of the box.
@@ -54,7 +58,7 @@ if (page.value?.ogImage) {
 }
 // Ensure the schema.org is rendered
 useHead(page.value.head || {}) // <-- Nuxt Schema.org
-useSeoMeta(page.value.seo || {}) // <-- Nuxt Robots
+useSeoMeta(page.value.seo || {}) // <-- useSeoMeta
 </script>
 ```
 


### PR DESCRIPTION
## Summary
- Fix troubleshooting.md description and remove duplicate StackBlitz section
- Fix misleading comment in nuxt-content.md (was "Nuxt Robots", now "useSeoMeta")
- Add debugging tools section to troubleshooting page
- Add callouts linking to SEO tools throughout docs

## Test plan
- [ ] Review rendered markdown for proper formatting
- [ ] Verify links to external tools work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)