### PR TITLE
docs: fix internal links to use correct paths

### DIFF
--- a/docs/content/1.getting-started/0.introduction.md
+++ b/docs/content/1.getting-started/0.introduction.md
@@ -5,7 +5,7 @@ navigation:
   title: 'Introduction'
 ---
 
-Nuxt SEO is a collection of Nuxt modules that handle [technical SEO](/learn/mastering-meta/getting-started/why-seo-matters) automatically, including sitemaps, robots.txt, Schema.org, and OG images. It combines 6 focused modules into one unified solution.
+Nuxt SEO is a collection of Nuxt modules that handle [technical SEO](/learn-seo/nuxt) automatically, including sitemaps, robots.txt, Schema.org, and OG images. It combines 6 focused modules into one unified solution.
 
 ## Background
 


### PR DESCRIPTION
## Summary
- Update `/learn/` links to `/learn-seo/nuxt/`
- Fix deprecated guide paths

These links were causing unnecessary redirects on nuxtseo.com.

🤖 Generated with [Claude Code](https://claude.ai/code)