### PR TITLE
fix(devtools): correct site-config debug endpoint URL

### DIFF
--- a/packages/devtools-layer/composables/checklist.ts
+++ b/packages/devtools-layer/composables/checklist.ts
@@ -41,7 +41,7 @@ export interface ChecklistSummary {
 
 // Debug endpoint paths for each module
 const DEBUG_ENDPOINTS: Partial<Record<NuxtSEOModule['slug'], string>> = {
-  'site-config': '/__site-config__/debug',
+  'site-config': '/__site-config__/debug.json',
   'robots': '/__robots__/debug.json',
   'sitemap': '/__sitemap__/debug.json',
   'og-image': '/__nuxt-og-image/debug.json',


### PR DESCRIPTION
## Summary
- Fixed the site-config debug endpoint path from `/__site-config__/debug` to `/__site-config__/debug.json` to match the actual route registered by `nuxt-site-config`
- This was causing all Setup tab checks (Site URL, Site name, locale, trailing slash) to show as unconfigured even when properly set in `nuxt.config`

## Test plan
- [ ] Open devtools Setup tab with `nuxt-site-config` module installed and `site` config set in `nuxt.config`
- [ ] Verify Site URL and Site name checks now pass correctly
- [ ] Verify other site-config checks (locale, trailing slash) reflect actual config

🤖 Generated with [Claude Code](https://claude.com/claude-code)