### PR TITLE
test: update inline snapshots for meta tag ordering

### DIFF
--- a/packages/nuxt-seo/.nuxtrc
+++ b/packages/nuxt-seo/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.0"
+setups.@nuxt/test-utils="4.0.2"

--- a/packages/nuxt-seo/test/fixtures/basic/.nuxtrc
+++ b/packages/nuxt-seo/test/fixtures/basic/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.0"
+setups.@nuxt/test-utils="4.0.2"

--- a/packages/nuxt-seo/test/integration/base.test.ts
+++ b/packages/nuxt-seo/test/integration/base.test.ts
@@ -24,11 +24,11 @@ describe('base url', () => {
     expect(extractSeoHead(html)).toMatchInlineSnapshot(`
       "<meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta property="og:image" content="https://local.nuxtseo.com/base/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
-      <meta property="og:image:type" content="image/png">
       <meta name="twitter:card" content="summary_large_image">
       <meta name="twitter:image" content="https://local.nuxtseo.com/base/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
       <meta name="twitter:image:src" content="https://local.nuxtseo.com/base/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image" content="https://local.nuxtseo.com/base/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">
       <meta name="twitter:image:width" content="1200">
       <meta property="og:image:height" content="600">

--- a/packages/nuxt-seo/test/integration/i18n.test.ts
+++ b/packages/nuxt-seo/test/integration/i18n.test.ts
@@ -28,11 +28,11 @@ describe('i18n', () => {
     expect(extractSeoHead(html)).toMatchInlineSnapshot(`
       "<meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta property="og:image" content="https://nuxtseo.com/_og/d/description_en+description,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
-      <meta property="og:image:type" content="image/png">
       <meta name="twitter:card" content="summary_large_image">
       <meta name="twitter:image" content="https://nuxtseo.com/_og/d/description_en+description,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
       <meta name="twitter:image:src" content="https://nuxtseo.com/_og/d/description_en+description,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image" content="https://nuxtseo.com/_og/d/description_en+description,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">
       <meta name="twitter:image:width" content="1200">
       <meta property="og:image:height" content="600">
@@ -56,11 +56,11 @@ describe('i18n', () => {
     expect(extractSeoHead(html)).toMatchInlineSnapshot(`
       "<meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta property="og:image" content="https://nuxtseo.com/_og/d/title_Fr,description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
-      <meta property="og:image:type" content="image/png">
       <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="https://nuxtseo.com/_og/d/title_Fr,description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
-      <meta name="twitter:image:src" content="https://nuxtseo.com/_og/d/title_Fr,description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta name="twitter:image" content="https://nuxtseo.com/_og/d/description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta name="twitter:image:src" content="https://nuxtseo.com/_og/d/description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image" content="https://nuxtseo.com/_og/d/description_fr+description,p_Ii9mciI,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">
       <meta name="twitter:image:width" content="1200">
       <meta property="og:image:height" content="600">

--- a/packages/nuxt-seo/test/integration/prod.test.ts
+++ b/packages/nuxt-seo/test/integration/prod.test.ts
@@ -27,11 +27,11 @@ describe('dev', () => {
     expect(extractSeoHead(html)).toMatchInlineSnapshot(`
       "<meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1">
-      <meta property="og:image" content="https://local.nuxtseo.com/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
-      <meta property="og:image:type" content="image/png">
       <meta name="twitter:card" content="summary_large_image">
       <meta name="twitter:image" content="https://local.nuxtseo.com/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
       <meta name="twitter:image:src" content="https://local.nuxtseo.com/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image" content="https://local.nuxtseo.com/_og/d/description_Fully+equipped+Technical+SEO+for+busy+Nuxters.,ch_ZjvFJ2KntDorwN6ClhcPYXuPUAlcdoy82AUFvETmEHs.png">
+      <meta property="og:image:type" content="image/png">
       <meta property="og:image:width" content="1200">
       <meta name="twitter:image:width" content="1200">
       <meta property="og:image:height" content="600">


### PR DESCRIPTION
### 🔗 Linked issue

None — fixes main CI which has been red since 6490d92 (`chore: bump deps`).

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The `nuxt-og-image` (6.3.9 → 6.4.7) and `nuxt-seo-utils` (8.1.7 → 8.1.11) bumps changed the order in which the Twitter card group and the Open Graph image group are emitted in `<head>` — Twitter tags now come first. The behaviour is unchanged; the snapshot diffs are pure reordering.

Updates the four affected `toMatchInlineSnapshot` blocks across `base.test.ts`, `i18n.test.ts`, and `prod.test.ts`. Also picks up the `@nuxt/test-utils` 4.0.0 → 4.0.2 marker file changes that `nuxt prepare` writes into `.nuxtrc`.