### PR TITLE
docs: fix disabling modules link

### DIFF
--- a/docs/content/2.guides/0.using-the-modules.md
+++ b/docs/content/2.guides/0.using-the-modules.md
@@ -66,7 +66,7 @@ Generate dynamic Open Graph images for your pages.
 - Opt-in, by default, it won't do anything unless you configure it.
 - See the [Tutorial: Getting Familiar With Nuxt OG Image](/docs/og-image/getting-started/getting-familiar-with-nuxt-og-image) docs on setting it up.
 
-Note: If you don't intend to generate dynamic images, it's recommended to [disable this module](/docs/nuxt-seo/guides/disabling-modules).
+Note: If you don't intend to generate dynamic images, it's recommended to [disable this module](/docs/nuxt-seo/guides/debugging-modules#disabling-modules).
 
 ## Schema.org
 


### PR DESCRIPTION
### 🔗 Linked issue

Refs #553

### ❓ Type of change

- [ ] 📦 New package
- [ ] 🥳 Enhancement
- [ ] 🐞 Bug fix
- [x] 📖 Documentation
- [ ] 🏡 Chore

### 📚 Description

Fixes the internal docs link for disabling Nuxt SEO modules so it points to the existing "Disabling Modules" section.

The direct `/docs/nuxt-seo/guides/disabling-modules` route/redirect is intentionally out of scope here, since that appears to require docs routing or deployment generation changes rather than a content-only update.