### PR TITLE
fix: raise nuxt-og-image compatibility floor to >=6.4.4

### DIFF
--- a/packages/nuxt-seo/src/module.ts
+++ b/packages/nuxt-seo/src/module.ts
@@ -28,7 +28,9 @@ export default defineNuxtModule<ModuleOptions>({
       version: '>=4.3',
     },
     'nuxt-og-image': {
-      version: '>=6.0',
+      // 6.4.3 could fail to load a native transitive binding (oxc-parser/lightningcss)
+      // in some environments, surfacing as a cryptic "Could not load nuxt-og-image".
+      version: '>=6.4.4',
     },
     'nuxt-schema-org': {
       version: '>=5.0',


### PR DESCRIPTION
## Context

Fresh `@nuxtjs/seo` installs reported `Could not load nuxt-og-image. Is it installed?` (harlan-zw/nuxt-seo#537). Root cause: that message is `@nuxt/kit`'s generic fallback, which masks the real error. `@nuxtjs/seo@5.1.3` floated `nuxt-og-image` to `6.4.3`, whose build module could fail to load a native transitive binding (`oxc-parser`/`lightningcss`) in certain environments (e.g. StackBlitz WebContainers), and kit reports it as a missing module.

## Change

Raise the `moduleDependencies['nuxt-og-image']` floor from `>=6.0` to `>=6.4.4` so a stale `6.4.3` in a user's tree is rejected with a clear compatibility message instead of the cryptic load failure.

The primary fix for fresh installs is the pending `@nuxtjs/seo` release: the workspace catalog is already at `nuxt-og-image: ^6.5.2`, so a new release skips `6.4.3` entirely. This PR is the defensive clarity layer.

Refs harlan-zw/nuxt-seo#537