### PR TITLE
fix(shared): add resolveHostUnheadMajor helper

### DIFF
--- a/packages/shared/src/kit.ts
+++ b/packages/shared/src/kit.ts
@@ -4,6 +4,7 @@ import type { NitroConfig } from 'nitropack/types'
 import type { NuxtModule, NuxtPage } from 'nuxt/schema'
 import { addTemplate, createResolver, hasNuxtModule, hasNuxtModuleCompatibility, loadNuxtModuleInstance, tryUseNuxt, useNuxt } from '@nuxt/kit'
 import { relative } from 'pathe'
+import { readPackageJSON } from 'pkg-types'
 import { env, provider } from 'std-env'
 
 export interface NuxtSeoModuleDetection {
@@ -167,4 +168,47 @@ export async function resolveNuxtContentVersion(): Promise<false | NuxtContentVe
   if (await hasNuxtModuleCompatibility('@nuxt/content', '^2'))
     return { version: 2 }
   return false
+}
+
+/**
+ * Read the major version of a non-module package as resolved from `rootDir`.
+ *
+ * Unlike `hasNuxtModuleCompatibility`, this works for plain libraries (e.g.
+ * `unhead`, `@unhead/vue`) that aren't registered as Nuxt modules. Returns
+ * `undefined` when the package can't be resolved or has no parseable version.
+ */
+export async function resolvePackageMajor(id: string, rootDir: string): Promise<number | undefined> {
+  const url = rootDir.endsWith('/') ? rootDir : `${rootDir}/`
+  const version = await readPackageJSON(id, { url }).then(pkg => pkg.version).catch(() => {
+    // an unresolvable package is an expected miss (it just isn't installed under
+    // this id); the caller decides on a fallback.
+    return undefined
+  })
+  const major = version ? Number.parseInt(version, 10) : Number.NaN
+  return Number.isFinite(major) ? major : undefined
+}
+
+export type UnheadMajor = 2 | 3
+
+/**
+ * Resolve the major of the unhead the host app renders with.
+ *
+ * `@unhead/vue` is what the head-stack packages peer-depend on, so it's the
+ * primary signal; falls back to the core `unhead` package, then to `3` (the
+ * current default major) when neither resolves.
+ *
+ * Used to keep head-stack dependencies on a compatible major. For example,
+ * `@unhead/schema-org` v3 attaches an object `_resolver` to every graph node
+ * that unhead v2's `walkResolver` invokes as a thunk, crashing render; a module
+ * that ships both majors can use this to alias to the matching one.
+ */
+export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMajor> {
+  for (const id of ['@unhead/vue', 'unhead']) {
+    const major = await resolvePackageMajor(id, rootDir)
+    if (major === 2)
+      return 2
+    if (major !== undefined && major >= 3)
+      return 3
+  }
+  return 3
 }


### PR DESCRIPTION
### 📚 Description

Adds two host-dependency version-detection helpers to `nuxtseo-shared/kit`, alongside the existing `resolveNuxtContentVersion`:

- `resolvePackageMajor(id, rootDir)` — reads the major of a non-module package (e.g. `unhead`, `@unhead/vue`) as resolved from `rootDir`. Unlike `hasNuxtModuleCompatibility`, it works for plain libraries that aren't registered Nuxt modules. Returns `undefined` when unresolvable.
- `resolveHostUnheadMajor(rootDir)` — resolves the unhead major the host renders with (via `@unhead/vue`, falling back to `unhead`, then `3`).

### Motivation

Extracted from the fix for harlan-zw/nuxt-schema-org#114, where `@unhead/schema-org` v3 paired with unhead v2 crashes render (unhead v2's `walkResolver` invokes schema-org's object `_resolver` as a thunk). nuxt-schema-org needs to detect the host unhead major to alias schema-org to a compatible copy. The detection itself is generic and belongs in shared; the schema-org-specific vendoring stays in that module.

### Follow-up

Once released, nuxt-schema-org will drop its local copy of `resolveHostUnheadMajor` and consume it from `nuxtseo-shared/kit`.