### PR TITLE
ci: make Playwright browser install opt-in

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -27,6 +27,10 @@ on:
         description: Enable Redis service container for tests
         type: boolean
         default: false
+      playwright:
+        description: Install Playwright browsers before tests (disable for repos with no browser tests)
+        type: boolean
+        default: true
 
 jobs:
   lint:
@@ -83,13 +87,14 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
+        if: ${{ inputs.playwright }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ inputs.runner }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: ${{ inputs.playwright && steps.playwright-cache.outputs.cache-hit != 'true' }}
         # The arm64 chromium download from cdn.playwright.dev can stall indefinitely;
         # bound each attempt and retry so a flaky CDN doesn't wedge the job for hours.
         run: |
@@ -134,13 +139,14 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
+        if: ${{ inputs.playwright }}
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ inputs.runner }}-${{ hashFiles('**/pnpm-lock.yaml') }}
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: ${{ inputs.playwright && steps.playwright-cache.outputs.cache-hit != 'true' }}
         # The arm64 chromium download from cdn.playwright.dev can stall indefinitely;
         # bound each attempt and retry so a flaky CDN doesn't wedge the job for hours.
         run: |


### PR DESCRIPTION
### 📚 Description

The reusable CI `test` job installs Chromium on every Playwright-browser cache miss. The cache key is `hashFiles('**/pnpm-lock.yaml')`, so any lockfile change forces a fresh ~183MB arm64 download from `cdn.playwright.dev`, which intermittently stalls at 100% (CDN delivers all bytes but never closes the connection). Repos like `nuxt-seo-utils` have no browser tests, so this is pure wasted CI time.

This adds a `playwright` input (default `true`, so existing behaviour is unchanged) that gates the cache + install steps in both the `test` and `test-redis` jobs. Consumers with no browser tests pass `playwright: false` to skip the download entirely.

### ❓ Type of change

- [x] 🧹 Chore