### PR TITLE
feat(devtools): unified devtools client + design alignment

### DIFF
--- a/packages/devtools-layer/app.config.ts
+++ b/packages/devtools-layer/app.config.ts
@@ -1,7 +1,7 @@
 export default {
   ui: {
     colors: {
-      primary: 'green',
+      primary: 'violet',
       neutral: 'neutral',
     },
     button: {

--- a/packages/devtools-layer/assets/css/global.css
+++ b/packages/devtools-layer/assets/css/global.css
@@ -21,23 +21,39 @@
   --font-sans: 'Hubot Sans', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'Fira Code', ui-monospace, monospace;
 
-  /* Neutral palette, true gray with minimal chroma */
-  --color-neutral-50: oklch(98% 0.002 260);
-  --color-neutral-100: oklch(96% 0.003 260);
-  --color-neutral-200: oklch(91% 0.005 260);
-  --color-neutral-300: oklch(85% 0.008 260);
-  --color-neutral-400: oklch(65% 0.015 260);
-  --color-neutral-500: oklch(50% 0.018 260);
-  --color-neutral-600: oklch(40% 0.015 260);
-  --color-neutral-700: oklch(30% 0.012 260);
-  --color-neutral-800: oklch(20% 0.01 260);
-  --color-neutral-900: oklch(14% 0.008 260);
-  --color-neutral-950: oklch(9% 0.005 260);
+  /* Neutral — slate realigned to the violet primary hue (292), chroma lifted so
+     a subtle violet warmth bleeds through every surface (matches DESIGN.md /
+     layers/design-system). Reads as a violet-tinted grey, not a cold blue-grey. */
+  --color-neutral-50: oklch(98.4% 0.005 292);
+  --color-neutral-100: oklch(96.8% 0.009 292);
+  --color-neutral-200: oklch(92.9% 0.020 292);
+  --color-neutral-300: oklch(86.9% 0.033 292);
+  --color-neutral-400: oklch(70.4% 0.052 292);
+  --color-neutral-500: oklch(55.4% 0.058 292);
+  --color-neutral-600: oklch(44.6% 0.056 292);
+  --color-neutral-700: oklch(32% 0.050 292);
+  --color-neutral-800: oklch(22% 0.044 292);
+  --color-neutral-900: oklch(16% 0.036 292);
+  --color-neutral-950: oklch(11% 0.029 292);
+
+  /* Primary — deep, rich violet (hue 292). Drives @nuxt/ui `primary: violet`. */
+  --color-violet-50: oklch(97.0% 0.037 292);
+  --color-violet-100: oklch(94.4% 0.065 292);
+  --color-violet-200: oklch(89.5% 0.110 292);
+  --color-violet-300: oklch(76.0% 0.150 292);
+  --color-violet-400: oklch(63.0% 0.180 292);
+  --color-violet-500: oklch(54.0% 0.225 292);
+  --color-violet-600: oklch(48.0% 0.240 292);
+  --color-violet-700: oklch(43.0% 0.230 292);
+  --color-violet-800: oklch(38.0% 0.200 292);
+  --color-violet-900: oklch(33.0% 0.165 292);
+  --color-violet-950: oklch(24.0% 0.120 292);
 }
 
 :root {
-  /* Brand colors - Nuxt SEO green */
-  --seo-green: oklch(65% 0.2 145);
+  /* Brand accent — violet primary (was Nuxt SEO green). Kept as --seo-green for
+     component compatibility; all 30+ usages now read as brand violet. */
+  --seo-green: var(--color-violet-500);
 
   /* Semantic colors */
   --color-surface: var(--color-neutral-50);
@@ -49,20 +65,47 @@
   --color-text-muted: var(--color-neutral-500);
   --color-text-subtle: var(--color-neutral-400);
 
+  /* Radius — aligned to DESIGN.md (sm 6 / md 8 / lg 12 / xl 16). */
   --radius-sm: 6px;
-  --radius-md: 10px;
-  --radius-lg: 14px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+
+  /* Focus ring — violet, matches design-system --shadow-focus. */
+  --shadow-focus: 0 0 0 3px color-mix(in oklab, var(--color-violet-500) 30%, transparent);
+
+  /* Depth & elevation ladder (from layers/design-system). Tier A ingredients
+     compose into Tier B presets — components reference only the presets:
+       inset   carved edge, no lift    flat   hairline ring, zero lift
+       raised  resting drop + bevel    overlay atmospheric + bevel (modals)
+       popover atmospheric + brand bevel (tooltip/dropdown) */
+  --_depth-ambient-low: 0 1px 2px rgb(0 0 0 / 0.03), 0 1px 5px rgb(0 0 0 / 0.035);
+  --_depth-ambient-high: 0 1px 1px 0 rgb(0 0 0 / 0.04), 0 2px 6px -2px rgb(0 0 0 / 0.06), 0 8px 16px -6px rgb(0 0 0 / 0.08);
+  --_depth-bevel: inset 0 1px 0 0 rgb(255 255 255 / 0.06), inset 0 -1px 0 0 rgb(0 0 0 / 0.04);
+  --_depth-bevel-brand: inset 0 1.5px 0 0 color-mix(in srgb, var(--color-violet-400) 26%, transparent), inset 0 -1px 0 0 rgb(0 0 0 / 0.04);
+  --_depth-ring: inset 0 0 0 1px var(--color-border);
+  --elevation-inset: var(--_depth-bevel);
+  --elevation-flat: var(--_depth-ring);
+  --elevation-raised: var(--_depth-ambient-low), var(--_depth-bevel);
+  --elevation-overlay: var(--_depth-ambient-high), var(--_depth-bevel);
+  --elevation-popover: var(--_depth-ambient-high), var(--_depth-bevel-brand);
 }
 
 .dark {
   --color-surface: var(--color-neutral-950);
   --color-surface-elevated: var(--color-neutral-900);
-  --color-surface-sunken: oklch(7% 0.004 260);
-  --color-border: oklch(25% 0.012 260);
-  --color-border-subtle: oklch(20% 0.01 260);
+  --color-surface-sunken: oklch(7% 0.018 292);
+  --color-border: oklch(25% 0.040 292);
+  --color-border-subtle: oklch(20% 0.034 292);
   --color-text: var(--color-neutral-100);
   --color-text-muted: var(--color-neutral-400);
   --color-text-subtle: var(--color-neutral-500);
+
+  /* Dark redefines the depth ingredients; presets inherit via var(). */
+  --_depth-ambient-low: 0 1px 2px rgb(0 0 0 / 0.35), 0 1px 5px rgb(0 0 0 / 0.22);
+  --_depth-ambient-high: 0 1px 1px 0 rgb(0 0 0 / 0.4), 0 2px 6px -2px rgb(0 0 0 / 0.35), 0 8px 16px -6px rgb(0 0 0 / 0.4);
+  --_depth-bevel: inset 0 1px 0 0 rgb(255 255 255 / 0.08), inset 0 -1px 0 0 rgb(0 0 0 / 0.2);
+  --_depth-bevel-brand: inset 0 1.5px 0 0 color-mix(in srgb, var(--color-violet-400) 40%, transparent), inset 0 -1px 0 0 rgb(0 0 0 / 0.2);
 }
 
 /* Base styles */

--- a/packages/devtools-layer/components/DevtoolsPanel.vue
+++ b/packages/devtools-layer/components/DevtoolsPanel.vue
@@ -48,12 +48,8 @@ defineEmits<{
   border-radius: var(--radius-lg);
   border: 1px solid var(--color-border);
   background: var(--color-surface-elevated);
-  box-shadow: 0 8px 32px oklch(0% 0 0 / 0.12);
+  box-shadow: var(--elevation-overlay);
   overflow: hidden;
-}
-
-.dark .devtools-panel {
-  box-shadow: 0 8px 32px oklch(0% 0 0 / 0.4);
 }
 
 .devtools-panel-header {

--- a/packages/devtools-layer/components/DevtoolsSection.vue
+++ b/packages/devtools-layer/components/DevtoolsSection.vue
@@ -61,11 +61,13 @@ function onToggle(e: any) {
   border-radius: var(--radius-lg);
   overflow: hidden;
   background: var(--color-surface-elevated);
-  transition: border-color 200ms ease;
+  box-shadow: var(--elevation-flat);
+  transition: border-color 200ms ease, box-shadow 200ms ease;
 }
 
 .section-block:hover {
   border-color: var(--color-neutral-300);
+  box-shadow: var(--elevation-raised);
 }
 
 .dark .section-block:hover {

--- a/packages/devtools-layer/package.json
+++ b/packages/devtools-layer/package.json
@@ -53,8 +53,8 @@
     "nuxtseo-shared": "workspace:*",
     "ofetch": "catalog:",
     "shiki": "catalog:",
-    "ufo": "catalog:",
-    "tailwindcss": "^4.0.0"
+    "tailwindcss": "catalog:",
+    "ufo": "catalog:"
   },
   "devDependencies": {
     "nuxt": "catalog:",

--- a/packages/devtools-layer/package.json
+++ b/packages/devtools-layer/package.json
@@ -22,6 +22,7 @@
   "exports": {
     ".": "./nuxt.config.ts",
     "./composables/shiki": "./composables/shiki.ts",
+    "./composables/host": "./composables/host.ts",
     "./composables/rpc": "./composables/rpc.ts",
     "./composables/state": "./composables/state.ts"
   },
@@ -37,6 +38,10 @@
     "public",
     "skills"
   ],
+  "scripts": {
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
   "dependencies": {
     "@nuxt/devtools-kit": "catalog:",
     "@nuxt/kit": "catalog:",
@@ -48,10 +53,12 @@
     "nuxtseo-shared": "workspace:*",
     "ofetch": "catalog:",
     "shiki": "catalog:",
-    "ufo": "catalog:"
+    "ufo": "catalog:",
+    "tailwindcss": "^4.0.0"
   },
   "devDependencies": {
     "nuxt": "catalog:",
+    "vitest": "catalog:",
     "vue": "catalog:"
   }
 }

--- a/packages/shared/playground/.gitignore
+++ b/packages/shared/playground/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.nuxt
+.output
+dist

--- a/packages/shared/playground/app.vue
+++ b/packages/shared/playground/app.vue
@@ -1,0 +1,5 @@
+<template>
+  <div style="font-family: sans-serif; padding: 2rem">
+    Nuxt SEO DevTools — Model C demo. Open Nuxt DevTools to see the assembled client.
+  </div>
+</template>

--- a/packages/shared/playground/layers/example-a/nuxt.config.ts
+++ b/packages/shared/playground/layers/example-a/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/packages/shared/playground/layers/example-a/pages/example-a.vue
+++ b/packages/shared/playground/layers/example-a/pages/example-a.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const navItems = [{ value: 'overview', to: '/example-a', icon: 'carbon:dashboard', label: 'Overview' }]
+</script>
+
+<template>
+  <DevtoolsLayout module-name="example-a" title="Example A" icon="carbon:bot" :nav-items="navItems" active-tab="overview">
+    <NuxtPage />
+  </DevtoolsLayout>
+</template>

--- a/packages/shared/playground/layers/example-a/pages/example-a/index.vue
+++ b/packages/shared/playground/layers/example-a/pages/example-a/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <DevtoolsSection icon="carbon:information" text="Example A">
+    <div class="p-4 text-sm">
+      This panel ships as a layer from an example module and is assembled into the one shared client.
+    </div>
+  </DevtoolsSection>
+</template>

--- a/packages/shared/playground/layers/example-b/nuxt.config.ts
+++ b/packages/shared/playground/layers/example-b/nuxt.config.ts
@@ -1,0 +1,1 @@
+export default defineNuxtConfig({})

--- a/packages/shared/playground/layers/example-b/pages/example-b.vue
+++ b/packages/shared/playground/layers/example-b/pages/example-b.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+const navItems = [{ value: 'overview', to: '/example-b', icon: 'carbon:dashboard', label: 'Overview' }]
+</script>
+
+<template>
+  <DevtoolsLayout module-name="example-b" title="Example B" icon="carbon:plug" :nav-items="navItems" active-tab="overview">
+    <NuxtPage />
+  </DevtoolsLayout>
+</template>

--- a/packages/shared/playground/layers/example-b/pages/example-b/index.vue
+++ b/packages/shared/playground/layers/example-b/pages/example-b/index.vue
@@ -1,0 +1,7 @@
+<template>
+  <DevtoolsSection icon="carbon:information" text="Example B">
+    <div class="p-4 text-sm">
+      This panel ships as a layer from an example module and is assembled into the one shared client.
+    </div>
+  </DevtoolsSection>
+</template>

--- a/packages/shared/playground/modules/seo-devtools-demo.ts
+++ b/packages/shared/playground/modules/seo-devtools-demo.ts
@@ -1,0 +1,21 @@
+import { createResolver, defineNuxtModule } from '@nuxt/kit'
+import { setupDevToolsUI } from 'nuxtseo-shared/devtools'
+
+// Demo: two example "modules" each register a devtools layer. Model C assembles them
+// into ONE client (built in node_modules/.cache, async with a Building… placeholder)
+// and serves it at /__nuxt-seo-devtools/<slug>. Real modules register the same way.
+const LAYERS = [
+  { slug: 'example-a', title: 'Example A', icon: 'carbon:bot' },
+  { slug: 'example-b', title: 'Example B', icon: 'carbon:plug' },
+]
+
+export default defineNuxtModule({
+  meta: { name: 'seo-devtools-demo' },
+  setup(_options, nuxt) {
+    const { resolve } = createResolver(import.meta.url)
+    for (const l of LAYERS) {
+      const layerDir = resolve(`../layers/${l.slug}`)
+      setupDevToolsUI({ name: l.slug, slug: l.slug, title: l.title, icon: l.icon }, () => layerDir, nuxt)
+    }
+  },
+})

--- a/packages/shared/playground/nuxt.config.ts
+++ b/packages/shared/playground/nuxt.config.ts
@@ -1,0 +1,5 @@
+export default defineNuxtConfig({
+  modules: ['./modules/seo-devtools-demo'],
+  devtools: { enabled: true },
+  compatibilityDate: '2026-03-13',
+})

--- a/packages/shared/playground/package.json
+++ b/packages/shared/playground/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "nuxtseo-shared-playground",
+  "private": true,
+  "type": "module",
+  "scripts": { "dev": "nuxi dev" },
+  "devDependencies": {
+    "@iconify-json/carbon": "^1.2.0",
+    "nuxt": "catalog:",
+    "nuxtseo-layer-devtools": "workspace:*",
+    "nuxtseo-shared": "workspace:*",
+    "shiki": "catalog:"
+  }
+}

--- a/packages/shared/src/devtools.ts
+++ b/packages/shared/src/devtools.ts
@@ -1,19 +1,26 @@
 import type { Resolver } from '@nuxt/kit'
 import type { BirpcGroup } from 'birpc'
 import type { Nuxt } from 'nuxt/schema'
-import { existsSync, readdirSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import { useNuxt } from '@nuxt/kit'
 import sirv from 'sirv'
 
 export type { BirpcGroup } from 'birpc'
 
+/** Origin-root route the assembled devtools client is served from. */
+export const UNIFIED_CLIENT_ROUTE = '/__nuxt-seo-devtools'
+
 export interface DevToolsUIConfig {
-  route: string
+  /** Legacy per-module route — no longer served; kept for back-compat. */
+  route?: string
   name: string
   title: string
   icon: string
-  devPort?: number
+  /** Route segment inside the client (e.g. `robots`). Defaults to name minus `nuxt-`. */
+  slug?: string
 }
 
 export interface SeoModuleInfo {
@@ -23,72 +30,123 @@ export interface SeoModuleInfo {
   route: string
 }
 
-export function setupDevToolsUI(config: DevToolsUIConfig, resolve: Resolver['resolve'], nuxt: Nuxt = useNuxt()): void {
-  const { route, name, title, icon, devPort = 3030 } = config
-  const clientPath = resolve('./devtools')
+interface SeoDevtoolsEntry {
+  slug: string
+  name: string
+  title: string
+  icon: string
+  layerDir: string
+}
 
-  // Register this module in the shared SEO modules registry
-  const modules: SeoModuleInfo[] = (nuxt as any)._seoDevtoolsModules ??= []
-  modules.push({ name, title, icon, route })
+const hashSet = (arr: string[]): string => [...JSON.stringify(arr)].reduce((h, c) => (h * 31 + c.charCodeAt(0)) >>> 0, 7).toString(36)
 
-  // Register shared RPC endpoint once (first module to call wins)
-  if (!(nuxt as any)._seoDevtoolsRpcRegistered) {
-    (nuxt as any)._seoDevtoolsRpcRegistered = true
-    onDevToolsInitialized(() => {
-      extendServerRpc('nuxt-seo-modules', {
-        getInstalledSeoModules(): SeoModuleInfo[] {
-          return (nuxt as any)._seoDevtoolsModules || []
-        },
-      }, nuxt)
-    }, nuxt)
+function placeholderHtml(): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Nuxt SEO DevTools</title>
+<style>html,body{margin:0;height:100%;font-family:'Hubot Sans',system-ui,sans-serif;background:oklch(98.4% 0.005 292);color:oklch(16% 0.036 292)}@media(prefers-color-scheme:dark){html,body{background:oklch(11% 0.029 292);color:oklch(96.8% 0.009 292)}}.wrap{height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:18px}.spin{width:34px;height:34px;border-radius:50%;border:3px solid color-mix(in oklab,oklch(54% 0.225 292) 25%,transparent);border-top-color:oklch(54% 0.225 292);animation:s .8s linear infinite}@keyframes s{to{transform:rotate(360deg)}}h1{font-size:15px;font-weight:600;margin:0}p{font-size:13px;opacity:.6;margin:0}</style></head>
+<body><div class="wrap"><div class="spin"></div><h1>Building Nuxt SEO DevTools…</h1><p>Assembling panels for your installed modules. This runs once.</p></div>
+<script>setInterval(async()=>{try{const r=await fetch('${UNIFIED_CLIENT_ROUTE}/__status');const j=await r.json();if(j.ready)location.reload()}catch{}},1000)</script></body></html>`
+}
+
+/** Full route list for a module: `/slug` + `/slug/<page>` for each non-index page. */
+function deriveRoutes(layerDir: string, slug: string): string[] {
+  const routes = [`/${slug}`]
+  const pagesDir = join(layerDir, 'pages', slug)
+  if (existsSync(pagesDir)) {
+    for (const f of readdirSync(pagesDir)) {
+      if (f.endsWith('.vue') && f !== 'index.vue')
+        routes.push(`/${slug}/${f.slice(0, -4)}`)
+    }
   }
-  const isProductionBuild = existsSync(clientPath) && readdirSync(clientPath).length > 0
+  return routes
+}
 
-  if (isProductionBuild) {
-    nuxt.hook('vite:serverCreated', (server) => {
-      server.middlewares.use(
-        route,
-        sirv(clientPath, { dev: true, single: true }),
-      )
-    })
-  }
-  else {
-    nuxt.hook('vite:extendConfig', (config) => {
-      Object.assign(config, {
-        server: {
-          ...config.server,
-          proxy: {
-            ...config.server?.proxy,
-            [route]: {
-              target: `http://localhost:${devPort}${route}`,
-              changeOrigin: true,
-              followRedirects: true,
-              ws: true,
-              rewrite: (p: string) => p.replace(route, ''),
-              configure: (proxy: any) => {
-                proxy.on('error', (err: Error, _req: any, res: any) => {
-                  if (res.headersSent)
-                    return
-                  res.writeHead(502, { 'Content-Type': 'text/plain' })
-                  res.end(`Devtools client not ready: ${err.message}`)
-                })
-              },
-            },
-          },
-        },
-      })
-    })
-  }
+function generateAndBuild(cacheDir: string, baseLayer: string, installed: SeoDevtoolsEntry[], onReady: () => void): void {
+  const routes = ['/', ...installed.flatMap(m => deriveRoutes(m.layerDir, m.slug))]
+  const extendsList = [baseLayer, ...installed.map(m => m.layerDir)]
+  mkdirSync(join(cacheDir, 'pages'), { recursive: true })
+  writeFileSync(join(cacheDir, 'nuxt.config.ts'), `import { resolve } from 'pathe'
+export default defineNuxtConfig({
+  extends: ${JSON.stringify(extendsList, null, 2)},
+  ssr: false,
+  robots: false,
+  content: false,
+  sitemap: false,
+  nitro: { prerender: { routes: ${JSON.stringify(routes)} }, output: { publicDir: resolve(__dirname, './dist/devtools') } },
+  app: { baseURL: '${UNIFIED_CLIENT_ROUTE}' },
+  compatibilityDate: '2026-03-13',
+})
+`)
+  writeFileSync(join(cacheDir, 'app.vue'), `<template><NuxtPage /></template>\n`)
+  writeFileSync(join(cacheDir, 'pages/index.vue'), `<template><div class="p-4">${installed.map(m => `<NuxtLink to="/${m.slug}" class="block underline">${m.title}</NuxtLink>`).join('')}</div></template>\n`)
 
-  addCustomTab({
-    name,
-    title,
-    icon,
-    view: {
-      type: 'iframe',
-      src: route,
-    },
+  // eslint-disable-next-line no-console
+  console.log(`[nuxt-seo] building devtools client for: ${installed.map(m => m.slug).join(', ')}`)
+  const child = spawn('npx', ['nuxi', 'build'], { cwd: cacheDir, stdio: 'inherit' })
+  child.on('exit', (code) => {
+    if (code === 0) {
+      writeFileSync(join(cacheDir, '.installed-hash'), hashSet(installed.map(m => m.slug).sort()))
+      onReady()
+      // eslint-disable-next-line no-console
+      console.log('[nuxt-seo] devtools client ready')
+    }
   })
+}
+
+/**
+ * Register a module's devtools panel. Each SEO module calls this from its module
+ * setup; the panels are assembled into ONE client built in the user's project from
+ * exactly the installed modules' layers (async, with a Building… placeholder), so the
+ * vendor/fonts/css ship once instead of per-module. First call wins the orchestration.
+ */
+export function setupDevToolsUI(config: DevToolsUIConfig, resolve: Resolver['resolve'], nuxt: Nuxt = useNuxt()): void {
+  if (!nuxt.options.dev)
+    return
+
+  const slug = config.slug ?? config.name.replace(/^nuxt-/, '')
+  const list: SeoDevtoolsEntry[] = (nuxt as any)._seoDevtoolsModules ??= []
+  list.push({ slug, name: config.name, title: config.title, icon: config.icon, layerDir: resolve('./devtools') })
+
+  if ((nuxt as any)._seoDevtoolsInit)
+    return
+  (nuxt as any)._seoDevtoolsInit = true
+
+  const cacheDir = join(nuxt.options.rootDir, 'node_modules/.cache/nuxt-seo-devtools')
+  const dist = join(cacheDir, 'dist/devtools')
+  const state = { ready: false }
+
+  // Build once after every module has registered.
+  nuxt.hook('modules:done', () => {
+    const installed: SeoDevtoolsEntry[] = (nuxt as any)._seoDevtoolsModules
+    const key = hashSet(installed.map(m => m.slug).sort())
+    state.ready = existsSync(join(cacheDir, '.installed-hash')) && readFileSync(join(cacheDir, '.installed-hash'), 'utf8') === key && existsSync(dist)
+    if (!state.ready)
+      generateAndBuild(cacheDir, 'nuxtseo-layer-devtools', installed, () => { state.ready = true })
+  })
+
+  // Serve: placeholder until ready, then the assembled client (connect strips the prefix).
+  nuxt.hook('vite:serverCreated', (server) => {
+    const serve = sirv(dist, { dev: true, single: '200.html' })
+    server.middlewares.use(UNIFIED_CLIENT_ROUTE, (req, res, next) => {
+      if ((req.url || '/').startsWith('/__status')) {
+        res.setHeader('content-type', 'application/json')
+        return res.end(JSON.stringify({ ready: state.ready }))
+      }
+      if (!state.ready) {
+        res.setHeader('content-type', 'text/html')
+        return res.end(placeholderHtml())
+      }
+      return serve(req, res, next)
+    })
+  })
+
+  onDevToolsInitialized(() => {
+    const installed: SeoDevtoolsEntry[] = (nuxt as any)._seoDevtoolsModules
+    extendServerRpc('nuxt-seo-modules', {
+      getInstalledSeoModules: (): SeoModuleInfo[] => installed.map(m => ({ name: m.slug, title: m.title, icon: m.icon, route: `${UNIFIED_CLIENT_ROUTE}/${m.slug}` })),
+    }, nuxt)
+    for (const m of installed)
+      addCustomTab({ name: `nuxt-seo-${m.slug}`, title: m.title, icon: m.icon, view: { type: 'iframe', src: `${UNIFIED_CLIENT_ROUTE}/${m.slug}` } })
+  }, nuxt)
 }
 
 export function setupDevToolsRpc<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       shiki:
         specifier: 'catalog:'
         version: 4.2.0
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.3.0
       ufo:
         specifier: 'catalog:'
         version: 1.6.4
@@ -259,6 +262,9 @@ importers:
       nuxt:
         specifier: 'catalog:'
         version: 4.4.7(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.5.2)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(better-sqlite3@12.8.0)))(drizzle-orm@0.45.2(better-sqlite3@12.8.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup@4.61.1))(rollup@4.61.1)(terser@5.46.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@types/node@25.5.2)(happy-dom@20.10.2)(vite@7.3.5(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))
       vue:
         specifier: 'catalog:'
         version: 3.5.35(typescript@6.0.3)
@@ -438,6 +444,24 @@ importers:
       vue-tsc:
         specifier: 'catalog:'
         version: 3.3.3(typescript@6.0.3)
+
+  packages/shared/playground:
+    devDependencies:
+      '@iconify-json/carbon':
+        specifier: ^1.2.0
+        version: 1.2.23
+      nuxt:
+        specifier: 'catalog:'
+        version: 4.4.7(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.5.2)(@vue/compiler-sfc@3.5.35)(better-sqlite3@12.8.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.8.0)(drizzle-orm@0.45.2(better-sqlite3@12.8.0)))(drizzle-orm@0.45.2(better-sqlite3@12.8.0))(eslint@10.4.1(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.3)(optionator@0.9.4)(rolldown@1.0.0-rc.10)(rollup-plugin-visualizer@7.0.1(rolldown@1.0.0-rc.10)(rollup@4.61.1))(rollup@4.61.1)(terser@5.46.1)(typescript@6.0.3)(vite@7.3.5(@types/node@25.5.2)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@3.3.3(typescript@6.0.3))(yaml@2.9.0)
+      nuxtseo-layer-devtools:
+        specifier: workspace:*
+        version: link:../../devtools-layer
+      nuxtseo-shared:
+        specifier: workspace:*
+        version: link:..
+      shiki:
+        specifier: 'catalog:'
+        version: 4.2.0
 
   packages/telemetry:
     dependencies:
@@ -1371,6 +1395,9 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/carbon@1.2.23':
+    resolution: {integrity: sha512-7apXetbRmEiWDXIQyikFJZyq7pCVBKHYRzmeLdtT7wWoHYdWHwnFcBAzpuLoSh+ZEAfXZapSWEe8iuS6dUqf+Q==}
 
   '@iconify/collections@1.0.693':
     resolution: {integrity: sha512-gY7LpY5x2hhZzuWZlsQ6Fl/vze2rfJA6C3NLHglha1pMCiC2IL1qsa1Xg8EpJPlKn80Kq3LhcEcRX1byZ+wMOg==}
@@ -10028,6 +10055,10 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/carbon@1.2.23':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify/collections@1.0.693':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     std-env:
       specifier: ^4.1.0
       version: 4.1.0
+    tailwindcss:
+      specifier: ^4.0.0
+      version: 4.3.0
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -253,7 +256,7 @@ importers:
         specifier: 'catalog:'
         version: 4.2.0
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.3.0
       ufo:
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -76,6 +76,7 @@ catalog:
   simple-git-hooks: ^2.13.1
   sirv: ^3.0.2
   std-env: ^4.1.0
+  tailwindcss: ^4.0.0
   typescript: ^6.0.3
   ufo: ^1.6.4
   unbuild: ^3.6.1


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Every SEO module ships its own prerendered devtools SPA today, so installing them pulls about 10MB of near-identical vendor JS, fonts and CSS with no sharing between modules. This makes `setupDevToolsUI` (in `nuxtseo-shared`) register-based: each installed module registers its devtools layer, and one client is assembled in your project from `nuxtseo-layer-devtools` plus the registered layers. It builds into `node_modules/.cache/nuxt-seo-devtools` in the background behind a "Building Nuxt SEO DevTools…" placeholder, serves at `/__nuxt-seo-devtools/<slug>` with a tab per module, caches by the installed-module set, and rebuilds only when that set changes. Every route is prerendered from each layer's pages.

It also aligns `nuxtseo-layer-devtools` with the nuxtseo.com `DESIGN.md`: violet primary (was green), violet-tinted slate neutral, and the `--elevation-*` ladder on `DevtoolsSection` and `DevtoolsPanel`.

To try it without merging the module PRs, run `packages/shared/playground`. Two example modules register layers and you get one assembled client with both panels.

### Companion PRs

Each ships its module's devtools as a layer and depends on this one:

- nuxt-modules/robots#301
- nuxt-modules/og-image#630
- nuxt-modules/sitemap#620
- harlan-zw/nuxt-schema-org#123
- harlan-zw/nuxt-site-config#96
- harlan-zw/nuxt-ai-ready#29
- harlan-zw/nuxt-seo-utils#117
- harlan-zw/nuxt-skew-protection#15
- harlan-zw/nuxt-link-checker#90

Publish this first, then the module PRs.
