### PR TITLE
fix(devtools): show all installed modules in the picker

### DIFF
--- a/packages/devtools-layer/composables/modules.ts
+++ b/packages/devtools-layer/composables/modules.ts
@@ -7,6 +7,8 @@ import { isConnected } from './state'
 
 export interface SeoModuleInfo {
   name: string
+  /** npm package name — stable identifier used to match installed state. */
+  npm?: string
   title: string
   icon: string
   route: string
@@ -68,11 +70,13 @@ export const showModuleSplash = ref(false)
 
 export const moduleCatalog = computed<SeoModuleCatalogEntry[]>(() => {
   return MODULE_CATALOG.map((entry) => {
-    const installed = installedModules.value.find(m => m.name === entry.name)
+    // Match on npm (stable, returned for every installed module) and fall back to the
+    // devtools name for older servers that only sent self-registered panels.
+    const installed = installedModules.value.find(m => (m.npm && m.npm === entry.npm) || m.name === entry.name)
     return {
       ...entry,
       installed: !!installed,
-      route: installed?.route,
+      route: installed?.route || undefined,
     }
   })
 })

--- a/packages/shared/src/devtools.ts
+++ b/packages/shared/src/devtools.ts
@@ -8,6 +8,13 @@ import { dirname, join } from 'node:path'
 import { addCustomTab, extendServerRpc, onDevToolsInitialized } from '@nuxt/devtools-kit'
 import { useNuxt } from '@nuxt/kit'
 import sirv from 'sirv'
+import { modules as seoModules } from './const'
+import { detectNuxtSeoModules } from './kit'
+
+/** Resolve a module's npm package name from its devtools slug. */
+function npmForSlug(slug: string): string | undefined {
+  return seoModules.find(m => m.slug === slug)?.npm
+}
 
 export type { BirpcGroup } from 'birpc'
 
@@ -28,6 +35,8 @@ export interface DevToolsUIConfig {
 
 export interface SeoModuleInfo {
   name: string
+  /** npm package name — the stable identifier the client matches installed state on. */
+  npm?: string
   title: string
   icon: string
   route: string
@@ -69,7 +78,24 @@ function registerSharedRpcOnce(nuxt: Nuxt): void {
   (nuxt as any)._seoDevtoolsRpcRegistered = true
   onDevToolsInitialized(() => {
     extendServerRpc('nuxt-seo-modules', {
-      getInstalledSeoModules: (): SeoModuleInfo[] => (nuxt as any)._seoDevtoolsModules || [],
+      // Registered modules (those that shipped a devtools panel) carry the iframe route.
+      // detectNuxtSeoModules adds every *installed* SEO module from nuxt's module list —
+      // independent of whether it self-registered a panel or which shared version it ships —
+      // so the picker reflects the full install (e.g. site-config, which has no panel).
+      getInstalledSeoModules: (): SeoModuleInfo[] => {
+        const byNpm = new Map<string, SeoModuleInfo>()
+        for (const m of ((nuxt as any)._seoDevtoolsModules || []) as SeoModuleInfo[]) {
+          if (m.npm)
+            byNpm.set(m.npm, m)
+        }
+        for (const det of detectNuxtSeoModules(nuxt)) {
+          if (!byNpm.has(det.name)) {
+            const meta = seoModules.find(s => s.npm === det.name)
+            byNpm.set(det.name, { name: meta?.slug ?? det.name, npm: det.name, title: meta?.label ?? det.name, icon: meta?.icon ?? '', route: '' })
+          }
+        }
+        return [...byNpm.values()]
+      },
     }, nuxt)
   }, nuxt)
 }
@@ -136,7 +162,7 @@ function setupLayerModule(config: DevToolsUIConfig, layerDir: string, nuxt: Nuxt
   const clientRoute = `${UNIFIED_CLIENT_ROUTE}/${slug}`
 
   const modules: SeoModuleInfo[] = (nuxt as any)._seoDevtoolsModules ??= []
-  modules.push({ name: config.name, title: config.title, icon: config.icon, route: clientRoute })
+  modules.push({ name: config.name, npm: npmForSlug(slug), title: config.title, icon: config.icon, route: clientRoute })
 
   const layers: SeoDevtoolsEntry[] = (nuxt as any)._seoDevtoolsLayers ??= []
   layers.push({ slug, name: config.name, title: config.title, icon: config.icon, layerDir })
@@ -182,10 +208,11 @@ function setupLayerModule(config: DevToolsUIConfig, layerDir: string, nuxt: Nuxt
  */
 function setupLegacyModule(config: DevToolsUIConfig, clientPath: string, nuxt: Nuxt): void {
   const { name, title, icon, devPort = 3030 } = config
-  const route = config.route ?? `/__${name.replace(/^nuxt-/, '')}`
+  const slug = config.slug ?? name.replace(/^nuxt-/, '')
+  const route = config.route ?? `/__${slug}`
 
   const modules: SeoModuleInfo[] = (nuxt as any)._seoDevtoolsModules ??= []
-  modules.push({ name, title, icon, route })
+  modules.push({ name, npm: npmForSlug(slug), title, icon, route })
 
   const isProductionBuild = existsSync(clientPath) && readdirSync(clientPath).length > 0
   if (isProductionBuild) {

--- a/packages/shared/src/devtools.ts
+++ b/packages/shared/src/devtools.ts
@@ -263,8 +263,9 @@ export function setupDevToolsUI(config: DevToolsUIConfig, resolve: Resolver['res
   // Published packages ship the layer at `<dist>/devtools`, but when a module runs from
   // source in dev (playground importing `../src/module`) it lives at `<root>/devtools`.
   // Prefer the dist-relative path, fall back to the source-relative one.
-  const layerCandidates = [resolve('./devtools'), resolve('../devtools')]
-  const layerDir = layerCandidates.find(dir => existsSync(join(dir, 'nuxt.config.ts'))) ?? layerCandidates[0]
+  const layerFallback = resolve('./devtools')
+  const layerCandidates = [layerFallback, resolve('../devtools')]
+  const layerDir = layerCandidates.find(dir => existsSync(join(dir, 'nuxt.config.ts'))) ?? layerFallback
   const isLayer = existsSync(join(layerDir, 'nuxt.config.ts')) && !existsSync(join(layerDir, 'index.html'))
 
   registerSharedRpcOnce(nuxt)


### PR DESCRIPTION
## Problem
The module picker only listed modules that self-registered a devtools panel via `setupDevToolsUI` (and only when shipping a current `nuxtseo-shared`). So real apps showed just one module, and panel-less dependencies like `nuxt-site-config` (which every module pulls in) never appeared.

## Fix
`getInstalledSeoModules` now merges two sources:
- **self-registered panels** from `nuxt._seoDevtoolsModules` — these carry the iframe `route` for switching;
- **`detectNuxtSeoModules(nuxt)`** — every installed SEO module from `nuxt.options._installedModules`, independent of devtools self-registration or shared version.

Entries are keyed by the stable **npm name**, and the client (`composables/modules.ts`) now matches installed state on `npm` (falling back to the devtools name for older servers). Panel-less modules (e.g. site-config) show as installed but without a switch route.

## Verification
`pnpm typecheck` passes for `packages/shared` + `packages/nuxt-seo`. **Needs runtime verification in a real multi-module app** (e.g. a project using `@nuxtjs/seo`): the picker should list every installed module incl. Site Config. I couldn't reproduce multi-module locally (the layer playground installs no modules).