### PR TITLE
feat(shared): ship server subpath, unify route-rule matcher and logger helpers

### DIFF
--- a/packages/shared/build.config.ts
+++ b/packages/shared/build.config.ts
@@ -11,9 +11,11 @@ export default defineBuildConfig({
     { input: 'src/pro', name: 'pro' },
     { input: 'src/utils', name: 'utils' },
     { input: 'src/const', name: 'const' },
+    { input: 'src/server', name: 'server' },
   ],
   externals: [
     /^nitropack/,
+    /^h3/,
     /^@nuxtjs\/i18n/,
     /^@nuxt\/content/,
     /^@nuxt\/schema/,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -52,6 +52,10 @@
       "types": "./dist/const.d.mts",
       "default": "./dist/const.mjs"
     },
+    "./server": {
+      "types": "./dist/server.d.mts",
+      "default": "./dist/server.mjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/module.mjs",
@@ -104,6 +108,7 @@
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",
     "@nuxtjs/i18n": "catalog:",
+    "h3": "catalog:",
     "nitropack": "catalog:",
     "nuxt": "catalog:",
     "nuxt-site-config": "catalog:",

--- a/packages/shared/src/kit.ts
+++ b/packages/shared/src/kit.ts
@@ -3,7 +3,7 @@ import type { Nitro } from 'nitropack'
 import type { NitroConfig } from 'nitropack/types'
 import type { NuxtModule, NuxtPage } from 'nuxt/schema'
 import { pathToFileURL } from 'node:url'
-import { addTemplate, createResolver, hasNuxtModule, hasNuxtModuleCompatibility, loadNuxtModuleInstance, tryUseNuxt, useNuxt } from '@nuxt/kit'
+import { addTemplate, createResolver, hasNuxtModule, hasNuxtModuleCompatibility, loadNuxtModuleInstance, tryUseNuxt, useLogger, useNuxt } from '@nuxt/kit'
 import { dirname, relative } from 'pathe'
 import { readPackageJSON, resolvePackageJSON } from 'pkg-types'
 import { env, provider } from 'std-env'
@@ -46,6 +46,12 @@ export function detectNuxtSeoModules(nuxt: Nuxt = useNuxt()): NuxtSeoModuleDetec
       version: m.meta.version,
       entryPath: m.entryPath,
     }))
+}
+
+export function useModuleLogger(name: string, options: { debug?: boolean }, nuxt: Nuxt = useNuxt()): ReturnType<typeof useLogger> {
+  const logger = useLogger(name)
+  logger.level = (options.debug || nuxt.options.debug) ? 4 : 3
+  return logger
 }
 
 const autodetectableProviders: Record<string, string> = {

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -1,15 +1,22 @@
+import type { H3Event } from 'h3'
 import type { NitroRouteRules } from 'nitropack'
 import { defu } from 'defu'
 import { useRuntimeConfig } from 'nitropack/runtime'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
-import { withoutBase, withoutTrailingSlash } from 'ufo'
+import { parseURL, withoutBase, withoutTrailingSlash } from 'ufo'
 
 export function withoutQuery(path: string): string {
-  return path.split('?')[0]
+  const queryIndex = path.indexOf('?')
+  return queryIndex === -1 ? path : path.slice(0, queryIndex)
 }
 
-export function createNitroRouteRuleMatcher(): (path: string) => NitroRouteRules {
-  const { nitro, app } = useRuntimeConfig()
+let cachedRouteRuleMatcher: ((pathOrUrl: string) => NitroRouteRules) | undefined
+
+export function createNitroRouteRuleMatcher(e?: H3Event): (pathOrUrl: string) => NitroRouteRules {
+  if (!import.meta.dev && !e && cachedRouteRuleMatcher)
+    return cachedRouteRuleMatcher
+
+  const { nitro, app } = useRuntimeConfig(e)
   const _routeRulesMatcher = toRouteMatcher(
     createRadixRouter({
       routes: Object.fromEntries(
@@ -18,9 +25,13 @@ export function createNitroRouteRuleMatcher(): (path: string) => NitroRouteRules
       ),
     }),
   )
-  return (path: string) => {
+  const matcher = (pathOrUrl: string): NitroRouteRules => {
+    const path = pathOrUrl[0] === '/' ? pathOrUrl : parseURL(pathOrUrl, app.baseURL).pathname
     return defu({}, ..._routeRulesMatcher.matchAll(
       withoutBase(withoutTrailingSlash(withoutQuery(path)), app.baseURL),
     ).reverse()) as NitroRouteRules
   }
+  if (!import.meta.dev && !e)
+    cachedRouteRuleMatcher = matcher
+  return matcher
 }

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -1,3 +1,5 @@
+import type { ConsolaInstance } from 'consola'
+import { createConsola } from 'consola'
 import { createRouter, toRouteMatcher } from 'radix3'
 
 export interface CreateFilterOptions {
@@ -53,4 +55,8 @@ export function createFilter(options: CreateFilterOptions = {}): (path: string) 
 
 export function withoutQuery(path: string): string {
   return path.split('?')[0]!
+}
+
+export function createModuleLogger(tag: string, debug?: boolean): ConsolaInstance {
+  return createConsola({ level: debug ? 4 : 3, defaults: { tag } })
 }

--- a/packages/shared/test/unit/server.test.ts
+++ b/packages/shared/test/unit/server.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useRuntimeConfigMock = vi.fn()
+
+vi.mock('nitropack/runtime', () => ({
+  useRuntimeConfig: (...args: any[]) => useRuntimeConfigMock(...args),
+}))
+
+function mockConfig(routeRules: Record<string, any>, baseURL = '/') {
+  useRuntimeConfigMock.mockReturnValue({ nitro: { routeRules }, app: { baseURL } })
+}
+
+async function importMatcher() {
+  vi.resetModules()
+  return import('../../src/server')
+}
+
+beforeEach(() => {
+  useRuntimeConfigMock.mockReset()
+})
+
+describe('createNitroRouteRuleMatcher', () => {
+  it('merges overlapping rules with defu precedence, more specific wins', async () => {
+    mockConfig({
+      '/blog/**': { headers: { a: '1' }, redirect: '/generic' },
+      '/blog/post/**': { headers: { a: '2', b: '3' } },
+    })
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const match = createNitroRouteRuleMatcher()
+    expect(match('/blog/post/abc')).toEqual({ headers: { a: '2', b: '3' }, redirect: '/generic' })
+  })
+
+  it('strips the baseURL before matching', async () => {
+    mockConfig({ '/foo': { redirect: '/x' } }, '/base')
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const match = createNitroRouteRuleMatcher()
+    expect(match('/base/foo')).toEqual({ redirect: '/x' })
+  })
+
+  it('strips trailing slash and query string', async () => {
+    mockConfig({ '/foo': { redirect: '/x' } })
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const match = createNitroRouteRuleMatcher()
+    expect(match('/foo/?a=1')).toEqual({ redirect: '/x' })
+  })
+
+  it('resolves a full URL input against the baseURL', async () => {
+    mockConfig({ '/foo': { redirect: '/x' } })
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const match = createNitroRouteRuleMatcher()
+    expect(match('https://example.com/foo?x=1')).toEqual({ redirect: '/x' })
+  })
+
+  it('caches the matcher across calls made without an event', async () => {
+    mockConfig({ '/foo': { redirect: '/x' } })
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    createNitroRouteRuleMatcher()
+    createNitroRouteRuleMatcher()
+    createNitroRouteRuleMatcher()
+    expect(useRuntimeConfigMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('never uses or populates the cache when an event is passed', async () => {
+    mockConfig({ '/foo': { redirect: '/x' } })
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const event = { context: {} } as any
+
+    createNitroRouteRuleMatcher()
+    createNitroRouteRuleMatcher(event)
+    createNitroRouteRuleMatcher(event)
+    createNitroRouteRuleMatcher()
+
+    expect(useRuntimeConfigMock).toHaveBeenCalledTimes(3)
+    expect(useRuntimeConfigMock).toHaveBeenNthCalledWith(2, event)
+    expect(useRuntimeConfigMock).toHaveBeenNthCalledWith(3, event)
+  })
+})

--- a/packages/shared/test/unit/utils.test.ts
+++ b/packages/shared/test/unit/utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { createModuleLogger } from '../../src/utils'
+
+describe('createModuleLogger', () => {
+  it('defaults to level 3 (info)', () => {
+    const logger = createModuleLogger('test-tag')
+    expect(logger.level).toBe(3)
+  })
+
+  it('uses level 4 (debug) when debug is true', () => {
+    const logger = createModuleLogger('test-tag', true)
+    expect(logger.level).toBe(4)
+  })
+
+  it('uses level 3 when debug is false', () => {
+    const logger = createModuleLogger('test-tag', false)
+    expect(logger.level).toBe(3)
+  })
+
+  it('tags the logger with the given tag', () => {
+    const logger = createModuleLogger('my-module')
+    expect(logger.options.defaults.tag).toBe('my-module')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ catalogs:
     execa:
       specifier: ^10.0.0
       version: 10.0.0
+    h3:
+      specifier: ^1.15.11
+      version: 1.15.11
     happy-dom:
       specifier: ^20.10.6
       version: 20.10.6
@@ -444,6 +447,9 @@ importers:
       '@nuxtjs/i18n':
         specifier: 'catalog:'
         version: 10.4.1(@vue/compiler-dom@3.5.40)(db0@0.3.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1)))(esbuild@0.28.0)(eslint@10.7.0(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.1.5(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.40(typescript@6.0.3))
+      h3:
+        specifier: 'catalog:'
+        version: 1.15.11
       nitropack:
         specifier: 'catalog:'
         version: 2.13.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1))(oxc-parser@0.140.0)(rolldown@1.2.0)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.1.5(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,6 +112,7 @@ catalog:
   eslint: ^10.7.0
   eslint-plugin-harlanzw: ^0.17.0
   execa: ^10.0.0
+  h3: ^1.15.11
   happy-dom: ^20.10.6
   jest-image-snapshot: ^6.5.2
   lint-staged: ^17.1.0


### PR DESCRIPTION
### 🔗 Linked issue

Related to the 9-repo cleanup sweep consolidating boilerplate into `nuxtseo-shared`. No specific issue tracks this.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`src/server.ts` already had `createNitroRouteRuleMatcher`, but it was never wired into `build.config.ts` or `package.json` exports, so every module repo (robots, sitemap) grew its own drifted copy instead of importing it. This ships the `./server` subpath and upgrades the matcher to the merged best-of those two copies: it now takes an optional `H3Event` (forwarded to `useRuntimeConfig(e)` so robots gets per-request config), accepts a path or a full URL, and only caches the matcher at module scope when no event was passed.

Also adds `createModuleLogger` (runtime, in `src/utils.ts`) and `useModuleLogger` (build-time, in `src/kit.ts`) to collapse the `createConsola({...})` + `logger.level = (config.debug || nuxt.options.debug) ? 4 : 3` pattern duplicated across robots/sitemap/og-image/schema-org/seo-utils/link-checker/skew-protection/ai-ready.

No behavior changes to existing shared exports. Unit tests cover the matcher (defu precedence, baseURL stripping, trailing-slash/query stripping, full-URL resolution, prod caching skipped when an event is passed) and `createModuleLogger` level selection.