### PR TITLE
feat(shared): filter serialization for runtimeConfig-safe patterns

### DIFF
--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -2,14 +2,69 @@ import type { ConsolaInstance } from 'consola'
 import { createConsola } from 'consola'
 import { createRouter, toRouteMatcher } from 'radix3'
 
+export interface SerializedRegExp {
+  regex: string
+}
+
+export interface SourceFlagsRegExp {
+  source: string
+  flags?: string
+}
+
+export type FilterEntry = string | RegExp
+export type SerializedFilterEntry = string | SerializedRegExp | SourceFlagsRegExp
+export type FilterEntryInput = FilterEntry | SerializedRegExp | SourceFlagsRegExp
+
+function parseSerializedRegExp(value: string): RegExp {
+  const lastSlash = value.lastIndexOf('/')
+  return new RegExp(value.slice(1, lastSlash), value.slice(lastSlash + 1))
+}
+
+export function serializeFilters(filters: unknown[], tag?: string): SerializedFilterEntry[] {
+  const prefix = tag ? `[${tag}] ` : ''
+  const result: SerializedFilterEntry[] = []
+  for (const filter of filters) {
+    if (filter instanceof RegExp) {
+      result.push({ regex: filter.toString() })
+      continue
+    }
+    if (typeof filter === 'string') {
+      result.push(filter)
+      continue
+    }
+    if (filter && typeof filter === 'object' && typeof (filter as SerializedRegExp).regex === 'string') {
+      result.push(filter as SerializedRegExp)
+      continue
+    }
+    if (filter && typeof filter === 'object' && typeof (filter as SourceFlagsRegExp).source === 'string') {
+      result.push(filter as SourceFlagsRegExp)
+      continue
+    }
+    console.warn(`${prefix}You have provided an invalid filter: ${filter}, ignoring.`)
+  }
+  return result
+}
+
+export function deserializeFilters(filters: FilterEntryInput[]): FilterEntry[] {
+  return filters.map((filter) => {
+    if (filter instanceof RegExp || typeof filter === 'string')
+      return filter
+    if (typeof (filter as SerializedRegExp).regex === 'string')
+      return parseSerializedRegExp((filter as SerializedRegExp).regex)
+    if (typeof (filter as SourceFlagsRegExp).source === 'string')
+      return new RegExp((filter as SourceFlagsRegExp).source, (filter as SourceFlagsRegExp).flags || '')
+    return filter as FilterEntry
+  })
+}
+
 export interface CreateFilterOptions {
-  include?: (string | RegExp)[]
-  exclude?: (string | RegExp)[]
+  include?: FilterEntryInput[]
+  exclude?: FilterEntryInput[]
 }
 
 export function createFilter(options: CreateFilterOptions = {}): (path: string) => boolean {
-  const include = options.include || []
-  const exclude = options.exclude || []
+  const include = deserializeFilters(options.include || [])
+  const exclude = deserializeFilters(options.exclude || [])
   if (include.length === 0 && exclude.length === 0)
     return () => true
 

--- a/packages/shared/test/unit/utils.test.ts
+++ b/packages/shared/test/unit/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { createModuleLogger } from '../../src/utils'
+import { describe, expect, it, vi } from 'vitest'
+import { createFilter, createModuleLogger, deserializeFilters, serializeFilters } from '../../src/utils'
 
 describe('createModuleLogger', () => {
   it('defaults to level 3 (info)', () => {
@@ -20,5 +20,122 @@ describe('createModuleLogger', () => {
   it('tags the logger with the given tag', () => {
     const logger = createModuleLogger('my-module')
     expect(logger.options.defaults.tag).toBe('my-module')
+  })
+})
+
+describe('createFilter', () => {
+  it('allows everything when no filters are provided', () => {
+    const filter = createFilter()
+    expect(filter('/foo')).toBe(true)
+    expect(filter('/bar/baz')).toBe(true)
+  })
+
+  it('matches string routes for include', () => {
+    const filter = createFilter({ include: ['/foo', '/bar/**'] })
+    expect(filter('/foo')).toBe(true)
+    expect(filter('/bar/baz')).toBe(true)
+    expect(filter('/baz')).toBe(false)
+  })
+
+  it('matches string routes for exclude', () => {
+    const filter = createFilter({ exclude: ['/foo', '/bar/**'] })
+    expect(filter('/foo')).toBe(false)
+    expect(filter('/bar/baz')).toBe(false)
+    expect(filter('/baz')).toBe(true)
+  })
+
+  it('matches RegExp instances for include', () => {
+    const filter = createFilter({ include: [/^\/foo/] })
+    expect(filter('/foo')).toBe(true)
+    expect(filter('/bar')).toBe(false)
+  })
+
+  it('matches RegExp instances for exclude', () => {
+    const filter = createFilter({ exclude: [/^\/foo/] })
+    expect(filter('/foo')).toBe(false)
+    expect(filter('/bar')).toBe(true)
+  })
+
+  it('exclude takes priority over include', () => {
+    const filter = createFilter({ include: ['/foo/**'], exclude: ['/foo/bar'] })
+    expect(filter('/foo/baz')).toBe(true)
+    expect(filter('/foo/bar')).toBe(false)
+  })
+
+  it('accepts serialized { regex } entries', () => {
+    const filter = createFilter({ include: [{ regex: '/^\\/foo/i' }] })
+    expect(filter('/FOO')).toBe(true)
+    expect(filter('/bar')).toBe(false)
+  })
+
+  it('accepts serialized { source, flags } entries', () => {
+    const filter = createFilter({ exclude: [{ source: '^\\/foo', flags: 'i' }] })
+    expect(filter('/FOO')).toBe(false)
+    expect(filter('/bar')).toBe(true)
+  })
+})
+
+describe('serializeFilters', () => {
+  it('passes strings through unchanged', () => {
+    expect(serializeFilters(['/foo'])).toEqual(['/foo'])
+  })
+
+  it('converts RegExp to canonical { regex } form', () => {
+    expect(serializeFilters([/^\/foo/gi])).toEqual([{ regex: '/^\\/foo/gi' }])
+  })
+
+  it('round-trips through JSON.stringify', () => {
+    const serialized = serializeFilters([/^\/foo/i, '/bar'])
+    const json = JSON.parse(JSON.stringify(serialized))
+    const deserialized = deserializeFilters(json)
+    expect(deserialized[0]).toBeInstanceOf(RegExp)
+    expect((deserialized[0] as RegExp).source).toBe('^\\/foo')
+    expect((deserialized[0] as RegExp).flags).toBe('i')
+    expect(deserialized[1]).toBe('/bar')
+  })
+
+  it('drops invalid entries and warns', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = serializeFilters([123, '/ok'])
+    expect(result).toEqual(['/ok'])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0]![0]).toContain('invalid filter')
+    warn.mockRestore()
+  })
+
+  it('prefixes the warning with the given tag', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    serializeFilters([null], 'my-module')
+    expect(warn.mock.calls[0]![0]).toContain('[my-module]')
+    warn.mockRestore()
+  })
+})
+
+describe('deserializeFilters', () => {
+  it('passes strings and RegExp through unchanged', () => {
+    const regex = /^\/foo/
+    const result = deserializeFilters(['/foo', regex])
+    expect(result[0]).toBe('/foo')
+    expect(result[1]).toBe(regex)
+  })
+
+  it('parses { regex } canonical entries', () => {
+    const [result] = deserializeFilters([{ regex: '/^\\/foo/gi' }])
+    expect(result).toBeInstanceOf(RegExp)
+    expect((result as RegExp).source).toBe('^\\/foo')
+    expect((result as RegExp).flags).toBe('gi')
+  })
+
+  it('parses { source, flags } legacy entries', () => {
+    const [result] = deserializeFilters([{ source: '^\\/foo', flags: 'i' }])
+    expect(result).toBeInstanceOf(RegExp)
+    expect((result as RegExp).source).toBe('^\\/foo')
+    expect((result as RegExp).flags).toBe('i')
+  })
+
+  it('parses { source } entries without flags', () => {
+    const [result] = deserializeFilters([{ source: '^\\/foo' }])
+    expect(result).toBeInstanceOf(RegExp)
+    expect((result as RegExp).flags).toBe('')
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None -- prep for a downstream cleanup in `@nuxtjs/sitemap` and `nuxt-link-checker`.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

RegExp include/exclude filters don't survive JSON serialization through Nuxt's `runtimeConfig`, so `@nuxtjs/sitemap` and `nuxt-link-checker` each built their own conversion to a plain-object wire format, and they picked different shapes (`{ regex }` vs `{ source, flags }`). Both call into `createFilter()` in `nuxtseo-shared`, which only understood live `RegExp` and strings.

Adds `serializeFilters()` / `deserializeFilters()` to `packages/shared/src/utils.ts`. `{ regex: string }` (the `RegExp.toString()` form) is the canonical wire format since sitemap already ships it in production. `deserializeFilters()` also accepts link-checker's `{ source, flags }` shape so both modules can swap over without a breaking change on their end. `createFilter()` now deserializes its `include`/`exclude` arrays internally, as a strict superset of the existing string/RegExp behavior.

Once released, `sitemap/src/utils-internal/filter.ts` and the serialize/deserialize helpers in `nuxt-link-checker/src/runtime/shared/sharedUtils.ts` can be deleted in favor of these.