### PR TITLE
fix(shared): make createNitroRouteRuleMatcher take runtimeConfig explicitly

### DIFF
--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -1,4 +1,3 @@
-import type { H3Event } from 'h3'
 import type { NitroRouteRules, NitroRuntimeConfig } from 'nitropack'
 import { defu } from 'defu'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
@@ -9,12 +8,7 @@ export function withoutQuery(path: string): string {
   return queryIndex === -1 ? path : path.slice(0, queryIndex)
 }
 
-let cachedRouteRuleMatcher: ((pathOrUrl: string) => NitroRouteRules) | undefined
-
-export function createNitroRouteRuleMatcher(runtimeConfig: NitroRuntimeConfig, e?: H3Event): (pathOrUrl: string) => NitroRouteRules {
-  if (!import.meta.dev && !e && cachedRouteRuleMatcher)
-    return cachedRouteRuleMatcher
-
+export function createNitroRouteRuleMatcher(runtimeConfig: NitroRuntimeConfig): (pathOrUrl: string) => NitroRouteRules {
   const { nitro, app } = runtimeConfig
   const _routeRulesMatcher = toRouteMatcher(
     createRadixRouter({
@@ -24,13 +18,10 @@ export function createNitroRouteRuleMatcher(runtimeConfig: NitroRuntimeConfig, e
       ),
     }),
   )
-  const matcher = (pathOrUrl: string): NitroRouteRules => {
+  return (pathOrUrl: string): NitroRouteRules => {
     const path = pathOrUrl[0] === '/' ? pathOrUrl : parseURL(pathOrUrl, app.baseURL).pathname
     return defu({}, ..._routeRulesMatcher.matchAll(
       withoutBase(withoutTrailingSlash(withoutQuery(path)), app.baseURL),
     ).reverse()) as NitroRouteRules
   }
-  if (!import.meta.dev && !e)
-    cachedRouteRuleMatcher = matcher
-  return matcher
 }

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -1,7 +1,6 @@
 import type { H3Event } from 'h3'
-import type { NitroRouteRules } from 'nitropack'
+import type { NitroRouteRules, NitroRuntimeConfig } from 'nitropack'
 import { defu } from 'defu'
-import { useRuntimeConfig } from 'nitropack/runtime'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import { parseURL, withoutBase, withoutTrailingSlash } from 'ufo'
 
@@ -12,11 +11,11 @@ export function withoutQuery(path: string): string {
 
 let cachedRouteRuleMatcher: ((pathOrUrl: string) => NitroRouteRules) | undefined
 
-export function createNitroRouteRuleMatcher(e?: H3Event): (pathOrUrl: string) => NitroRouteRules {
+export function createNitroRouteRuleMatcher(runtimeConfig: NitroRuntimeConfig, e?: H3Event): (pathOrUrl: string) => NitroRouteRules {
   if (!import.meta.dev && !e && cachedRouteRuleMatcher)
     return cachedRouteRuleMatcher
 
-  const { nitro, app } = useRuntimeConfig(e)
+  const { nitro, app } = runtimeConfig
   const _routeRulesMatcher = toRouteMatcher(
     createRadixRouter({
       routes: Object.fromEntries(

--- a/packages/shared/test/unit/server.test.ts
+++ b/packages/shared/test/unit/server.test.ts
@@ -1,17 +1,12 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { createNitroRouteRuleMatcher } from '../../src/server'
 
 function rc(routeRules: Record<string, any>, baseURL = '/') {
   return { nitro: { routeRules }, app: { baseURL } } as any
 }
 
-async function importMatcher() {
-  vi.resetModules()
-  return import('../../src/server')
-}
-
 describe('createNitroRouteRuleMatcher', () => {
-  it('merges overlapping rules with defu precedence, more specific wins', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
+  it('merges overlapping rules with defu precedence, more specific wins', () => {
     const match = createNitroRouteRuleMatcher(rc({
       '/blog/**': { headers: { a: '1' }, redirect: '/generic' },
       '/blog/post/**': { headers: { a: '2', b: '3' } },
@@ -19,41 +14,32 @@ describe('createNitroRouteRuleMatcher', () => {
     expect(match('/blog/post/abc')).toEqual({ headers: { a: '2', b: '3' }, redirect: '/generic' })
   })
 
-  it('strips the baseURL before matching', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
+  it('strips the baseURL before matching', () => {
     const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }, '/base'))
     expect(match('/base/foo')).toEqual({ redirect: '/x' })
   })
 
-  it('strips trailing slash and query string', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
+  it('strips trailing slash and query string', () => {
     const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
     expect(match('/foo/?a=1')).toEqual({ redirect: '/x' })
   })
 
-  it('resolves a full URL input against the baseURL', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
+  it('resolves a full URL input against the baseURL', () => {
     const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
     expect(match('https://example.com/foo?x=1')).toEqual({ redirect: '/x' })
   })
 
-  it('caches the matcher across calls made without an event, ignoring later config', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
-    const first = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
-    const second = createNitroRouteRuleMatcher(rc({ '/bar': { redirect: '/y' } }))
-    expect(second).toBe(first)
-    expect(second('/bar')).toEqual({})
-    expect(second('/foo')).toEqual({ redirect: '/x' })
+  it('returns an empty object when no rule matches', () => {
+    const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
+    expect(match('/bar')).toEqual({})
   })
 
-  it('never uses or populates the cache when an event is passed', async () => {
-    const { createNitroRouteRuleMatcher } = await importMatcher()
-    const event = { context: {} } as any
-    const withEvent = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }), event)
-    const withEvent2 = createNitroRouteRuleMatcher(rc({ '/bar': { redirect: '/y' } }), event)
-    expect(withEvent2).not.toBe(withEvent)
-    expect(withEvent2('/bar')).toEqual({ redirect: '/y' })
-    const globalMatch = createNitroRouteRuleMatcher(rc({ '/baz': { redirect: '/z' } }))
-    expect(globalMatch('/baz')).toEqual({ redirect: '/z' })
+  it('builds an independent matcher per call from the given config', () => {
+    const first = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
+    const second = createNitroRouteRuleMatcher(rc({ '/bar': { redirect: '/y' } }))
+    expect(first('/foo')).toEqual({ redirect: '/x' })
+    expect(first('/bar')).toEqual({})
+    expect(second('/bar')).toEqual({ redirect: '/y' })
+    expect(second('/foo')).toEqual({})
   })
 })

--- a/packages/shared/test/unit/server.test.ts
+++ b/packages/shared/test/unit/server.test.ts
@@ -1,13 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-const useRuntimeConfigMock = vi.fn()
-
-vi.mock('nitropack/runtime', () => ({
-  useRuntimeConfig: (...args: any[]) => useRuntimeConfigMock(...args),
-}))
-
-function mockConfig(routeRules: Record<string, any>, baseURL = '/') {
-  useRuntimeConfigMock.mockReturnValue({ nitro: { routeRules }, app: { baseURL } })
+function rc(routeRules: Record<string, any>, baseURL = '/') {
+  return { nitro: { routeRules }, app: { baseURL } } as any
 }
 
 async function importMatcher() {
@@ -15,63 +9,51 @@ async function importMatcher() {
   return import('../../src/server')
 }
 
-beforeEach(() => {
-  useRuntimeConfigMock.mockReset()
-})
-
 describe('createNitroRouteRuleMatcher', () => {
   it('merges overlapping rules with defu precedence, more specific wins', async () => {
-    mockConfig({
+    const { createNitroRouteRuleMatcher } = await importMatcher()
+    const match = createNitroRouteRuleMatcher(rc({
       '/blog/**': { headers: { a: '1' }, redirect: '/generic' },
       '/blog/post/**': { headers: { a: '2', b: '3' } },
-    })
-    const { createNitroRouteRuleMatcher } = await importMatcher()
-    const match = createNitroRouteRuleMatcher()
+    }))
     expect(match('/blog/post/abc')).toEqual({ headers: { a: '2', b: '3' }, redirect: '/generic' })
   })
 
   it('strips the baseURL before matching', async () => {
-    mockConfig({ '/foo': { redirect: '/x' } }, '/base')
     const { createNitroRouteRuleMatcher } = await importMatcher()
-    const match = createNitroRouteRuleMatcher()
+    const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }, '/base'))
     expect(match('/base/foo')).toEqual({ redirect: '/x' })
   })
 
   it('strips trailing slash and query string', async () => {
-    mockConfig({ '/foo': { redirect: '/x' } })
     const { createNitroRouteRuleMatcher } = await importMatcher()
-    const match = createNitroRouteRuleMatcher()
+    const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
     expect(match('/foo/?a=1')).toEqual({ redirect: '/x' })
   })
 
   it('resolves a full URL input against the baseURL', async () => {
-    mockConfig({ '/foo': { redirect: '/x' } })
     const { createNitroRouteRuleMatcher } = await importMatcher()
-    const match = createNitroRouteRuleMatcher()
+    const match = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
     expect(match('https://example.com/foo?x=1')).toEqual({ redirect: '/x' })
   })
 
-  it('caches the matcher across calls made without an event', async () => {
-    mockConfig({ '/foo': { redirect: '/x' } })
+  it('caches the matcher across calls made without an event, ignoring later config', async () => {
     const { createNitroRouteRuleMatcher } = await importMatcher()
-    createNitroRouteRuleMatcher()
-    createNitroRouteRuleMatcher()
-    createNitroRouteRuleMatcher()
-    expect(useRuntimeConfigMock).toHaveBeenCalledTimes(1)
+    const first = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }))
+    const second = createNitroRouteRuleMatcher(rc({ '/bar': { redirect: '/y' } }))
+    expect(second).toBe(first)
+    expect(second('/bar')).toEqual({})
+    expect(second('/foo')).toEqual({ redirect: '/x' })
   })
 
   it('never uses or populates the cache when an event is passed', async () => {
-    mockConfig({ '/foo': { redirect: '/x' } })
     const { createNitroRouteRuleMatcher } = await importMatcher()
     const event = { context: {} } as any
-
-    createNitroRouteRuleMatcher()
-    createNitroRouteRuleMatcher(event)
-    createNitroRouteRuleMatcher(event)
-    createNitroRouteRuleMatcher()
-
-    expect(useRuntimeConfigMock).toHaveBeenCalledTimes(3)
-    expect(useRuntimeConfigMock).toHaveBeenNthCalledWith(2, event)
-    expect(useRuntimeConfigMock).toHaveBeenNthCalledWith(3, event)
+    const withEvent = createNitroRouteRuleMatcher(rc({ '/foo': { redirect: '/x' } }), event)
+    const withEvent2 = createNitroRouteRuleMatcher(rc({ '/bar': { redirect: '/y' } }), event)
+    expect(withEvent2).not.toBe(withEvent)
+    expect(withEvent2('/bar')).toEqual({ redirect: '/y' })
+    const globalMatch = createNitroRouteRuleMatcher(rc({ '/baz': { redirect: '/z' } }))
+    expect(globalMatch('/baz')).toEqual({ redirect: '/z' })
   })
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix
- [x] ⚠️ Breaking change (internal `nuxtseo-shared/server` API)

### 📚 Description

`nuxtseo-shared/server`'s `createNitroRouteRuleMatcher` called `useRuntimeConfig` internally, which pulled a `nitropack/runtime` import into the published `/server` bundle. When a consumer module bundles that subpath into its Nitro runtime, Nitro externalizes the npm dependency instead of applying its virtual-module rewrite, so every request crashes with `ERR_PACKAGE_IMPORT_NOT_DEFINED` for `#nitro-internal-virtual/storage`. It surfaced as 22 failing e2e suites in `@nuxtjs/robots` and 63 in `@nuxtjs/sitemap` during the 5.3.4 adoption; both worked around it with `nitro.externals.inline.push('nuxtseo-shared')`.

This removes the root cause: the matcher now takes `runtimeConfig` as its first argument, so `/server` ships no `nitropack/runtime` import and there is nothing for Nitro to externalize. Callers pass their own `useRuntimeConfig(e)`, which resolves correctly inside their Nitro-processed runtime. The `externals.inline` workaround can then be dropped from consumers.

New signature: `createNitroRouteRuleMatcher(runtimeConfig, e?)`. Caching semantics are unchanged (cached only when no event is passed). The built `dist/server.mjs` now contains zero `nitropack` imports.