### PR TITLE
chore(ci): pack reusable nightlies with pnpm

### DIFF
--- a/.github/workflows/reusable-nightly.yml
+++ b/.github/workflows/reusable-nightly.yml
@@ -50,4 +50,4 @@ jobs:
       - run: pnpm build
 
       - name: Publish
-        run: pnpm dlx pkg-pr-new publish ${{ inputs.publish-packages }}
+        run: pnpm dlx pkg-pr-new publish --pnpm ${{ inputs.publish-packages }}


### PR DESCRIPTION
### 🔗 Linked issue

Related to harlan-zw/nuxt-site-config#101

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

The reusable nightly workflow invokes pkg-pr-new without pnpm workspace handling, leaving `catalog:` specifiers in downstream tarballs such as `nuxt-site-config@1bfc277`. Pass `--pnpm` so pkg-pr-new converts workspace catalog dependencies before publishing.