### PR TITLE
feat(shared): normalize Nitro runtime APIs

### DIFF
--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -53,6 +53,7 @@ const nitroV3Compatibility: NitroRuntimeCompatibility = {
 const nitroV2Runtime = `export {
   defineNitroPlugin,
   useNitroApp,
+  useEvent,
   useRuntimeConfig,
   defineCachedFunction,
   useStorage,
@@ -63,6 +64,7 @@ const nitroV2Runtime = `export {
 
 const nitroV3Runtime = `export { definePlugin as defineNitroPlugin } from 'nitro'
 export { useNitroApp } from 'nitro/app'
+export { useRequest as useEvent } from 'nitro/context'
 export { useRuntimeConfig } from 'nitro/runtime-config'
 export { defineCachedFunction } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -19,6 +19,7 @@ export type NitroRuntimeCompatibility
 
 export interface NitroTypeAugmentations {
   eventContext?: string
+  nitroInterfaces?: Record<string, string>
   routeConfig?: string
   routeRules?: string
   runtimeHooks?: string
@@ -27,6 +28,7 @@ export interface NitroTypeAugmentations {
 const NITRO_RUNTIME_MODULE = '#nuxtseo/nitro'
 const H3_RUNTIME_MODULE = '#nuxtseo/h3'
 const TYPE_TEMPLATE_FILENAME = 'types/nuxtseo-nitro.d.ts'
+const legacySetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility')
 const typeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context-types')
 const runtimeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context')
 
@@ -127,11 +129,15 @@ export function renderNitroTypeAugmentations(
     renderInterface('NitroRouteRules', augmentations.routeRules),
     renderInterface('NitroRouteConfig', augmentations.routeConfig),
     renderInterface('NitroRuntimeHooks', augmentations.runtimeHooks),
+    ...Object.entries(augmentations.nitroInterfaces || {}).map(([name, contents]) => renderInterface(name, contents)),
   ].filter((value): value is string => Boolean(value))
 
   const declarations: string[] = []
   if (nitroInterfaces.length) {
-    declarations.push(`declare module '${compatibility.nitroTypesModule}' {\n${nitroInterfaces.join('\n')}\n}`)
+    const nitroTypeModules = compatibility._tag === 'nitro-v2'
+      ? ['nitropack', 'nitropack/types']
+      : [compatibility.nitroTypesModule]
+    declarations.push(...nitroTypeModules.map(module => `declare module '${module}' {\n${nitroInterfaces.join('\n')}\n}`))
   }
   if (augmentations.eventContext?.trim()) {
     declarations.push(`declare module '${compatibility.eventContextModule}' {\n${renderInterface(compatibility.eventContextType, augmentations.eventContext)}\n}`)
@@ -143,6 +149,9 @@ export function setupNitroRuntimeCompatibility(nuxt: Nuxt = useNuxt()): NitroRun
   const major = Number.parseInt(getNuxtVersion(nuxt), 10)
   const compatibility = major >= 5 ? nitroV3Compatibility : nitroV2Compatibility
   applyNitroRuntimeCompatibility(nuxt, compatibility)
+
+  const nuxtWithLegacyMarker = nuxt as Nuxt & { [legacySetupMarker]?: true }
+  nuxtWithLegacyMarker[legacySetupMarker] = true
 
   const nuxtWithRuntimeMarker = nuxt as Nuxt & { [runtimeSetupMarker]?: true }
   if (!nuxtWithRuntimeMarker[runtimeSetupMarker]) {

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -27,7 +27,7 @@ export interface NitroTypeAugmentations {
 const NITRO_RUNTIME_MODULE = '#nuxtseo/nitro'
 const H3_RUNTIME_MODULE = '#nuxtseo/h3'
 const TYPE_TEMPLATE_FILENAME = 'types/nuxtseo-nitro.d.ts'
-const setupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility')
+const typeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context-types')
 const runtimeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context')
 
 interface NuxtNitroCompatibilityOptions {
@@ -139,9 +139,9 @@ export function setupNitroRuntimeCompatibility(nuxt: Nuxt = useNuxt()): NitroRun
     nuxt.hooks.hookOnce('modules:done', () => applyNitroRuntimeCompatibility(nuxt, compatibility))
   }
 
-  const nuxtWithMarker = nuxt as Nuxt & { [setupMarker]?: true }
-  if (!nuxtWithMarker[setupMarker]) {
-    nuxtWithMarker[setupMarker] = true
+  const nuxtWithTypeMarker = nuxt as Nuxt & { [typeSetupMarker]?: true }
+  if (!nuxtWithTypeMarker[typeSetupMarker]) {
+    nuxtWithTypeMarker[typeSetupMarker] = true
     addTypeTemplate({
       filename: TYPE_TEMPLATE_FILENAME,
       getContents: async () => renderRuntimeDeclarations(compatibility),

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -67,7 +67,7 @@ const nitroV3Runtime = `export { definePlugin as defineNitroPlugin } from 'nitro
 export { useNitroApp } from 'nitro/app'
 export { useRequest as useEvent } from 'nitro/context'
 export { useRuntimeConfig } from 'nitro/runtime-config'
-export { defineCachedFunction } from 'nitro/cache'
+export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
 `

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -28,6 +28,7 @@ const NITRO_RUNTIME_MODULE = '#nuxtseo/nitro'
 const H3_RUNTIME_MODULE = '#nuxtseo/h3'
 const TYPE_TEMPLATE_FILENAME = 'types/nuxtseo-nitro.d.ts'
 const setupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility')
+const runtimeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context')
 
 interface NuxtNitroCompatibilityOptions {
   alias?: Record<string, string>
@@ -98,6 +99,15 @@ ${indent(h3Runtime.trim(), 2)}
 `
 }
 
+function applyNitroRuntimeCompatibility(nuxt: Nuxt, compatibility: NitroRuntimeCompatibility): void {
+  const nuxtOptions = nuxt.options as Nuxt['options'] & { nitro?: NuxtNitroCompatibilityOptions }
+  const nitroOptions = nuxtOptions.nitro ||= {}
+  nitroOptions.alias ||= {}
+  nitroOptions.virtual ||= {}
+  nitroOptions.alias[H3_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
+  nitroOptions.virtual[NITRO_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime
+}
+
 export function renderNitroTypeAugmentations(
   compatibility: NitroRuntimeCompatibility,
   augmentations: NitroTypeAugmentations,
@@ -121,12 +131,13 @@ export function renderNitroTypeAugmentations(
 export function setupNitroRuntimeCompatibility(nuxt: Nuxt = useNuxt()): NitroRuntimeCompatibility {
   const major = Number.parseInt(getNuxtVersion(nuxt), 10)
   const compatibility = major >= 5 ? nitroV3Compatibility : nitroV2Compatibility
-  const nuxtOptions = nuxt.options as Nuxt['options'] & { nitro?: NuxtNitroCompatibilityOptions }
-  const nitroOptions = nuxtOptions.nitro ||= {}
-  nitroOptions.alias ||= {}
-  nitroOptions.virtual ||= {}
-  nitroOptions.alias[H3_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
-  nitroOptions.virtual[NITRO_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime
+  applyNitroRuntimeCompatibility(nuxt, compatibility)
+
+  const nuxtWithRuntimeMarker = nuxt as Nuxt & { [runtimeSetupMarker]?: true }
+  if (!nuxtWithRuntimeMarker[runtimeSetupMarker]) {
+    nuxtWithRuntimeMarker[runtimeSetupMarker] = true
+    nuxt.hooks.hookOnce('modules:done', () => applyNitroRuntimeCompatibility(nuxt, compatibility))
+  }
 
   const nuxtWithMarker = nuxt as Nuxt & { [setupMarker]?: true }
   if (!nuxtWithMarker[setupMarker]) {

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -67,7 +67,17 @@ const nitroV2Runtime = `export {
 const nitroV3Runtime = `export { definePlugin as defineNitroPlugin } from 'nitro'
 export { useNitroApp } from 'nitro/app'
 export { useRequest as useEvent } from 'nitro/context'
-export { useRuntimeConfig } from 'nitro/runtime-config'
+import { useRuntimeConfig as _useRuntimeConfig } from 'nitro/runtime-config'
+export function useRuntimeConfig(_event) { return _useRuntimeConfig() }
+export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
+export { useStorage } from 'nitro/storage'
+export { defineTask, runTask } from 'nitro/task'
+`
+
+const nitroV3RuntimeTypes = `export { definePlugin as defineNitroPlugin } from 'nitro'
+export { useNitroApp } from 'nitro/app'
+export { useRequest as useEvent } from 'nitro/context'
+export function useRuntimeConfig(event?: import('nitro/h3').H3Event): ReturnType<typeof import('nitro/runtime-config').useRuntimeConfig>
 export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
@@ -85,7 +95,7 @@ function renderInterface(name: string, contents?: string): string | undefined {
 }
 
 function renderRuntimeDeclarations(compatibility: NitroRuntimeCompatibility): string {
-  const nitroRuntime = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime
+  const nitroRuntime = compatibility._tag === 'nitro-v3' ? nitroV3RuntimeTypes : nitroV2Runtime
   const h3Runtime = compatibility._tag === 'nitro-v3'
     ? `export * from 'nitro/h3'\n`
     : `export * from 'h3'\n`

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -57,6 +57,7 @@ const nitroV2Runtime = `export {
   useEvent,
   useRuntimeConfig,
   defineCachedFunction,
+  defineCachedEventHandler,
   useStorage,
   defineTask,
   runTask,

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -17,7 +17,7 @@ export function withoutQuery(path: string): string {
 }
 
 export function createNitroRouteRuleMatcher<TRouteRules extends object = Record<string, unknown>>(
-  runtimeConfig: NitroRouteRulesRuntimeConfig<TRouteRules>,
+  runtimeConfig: NitroRouteRulesRuntimeConfig<object>,
 ): (pathOrUrl: string) => TRouteRules {
   const { nitro, app } = runtimeConfig
   const baseURL = app?.baseURL || '/'

--- a/packages/shared/src/server.ts
+++ b/packages/shared/src/server.ts
@@ -2,7 +2,7 @@ import { defu } from 'defu'
 import { createRouter as createRadixRouter, toRouteMatcher } from 'radix3'
 import { parseURL, withoutBase, withoutTrailingSlash } from 'ufo'
 
-export interface NitroRouteRulesRuntimeConfig<TRouteRules extends Record<string, unknown>> {
+export interface NitroRouteRulesRuntimeConfig<TRouteRules extends object> {
   app?: {
     baseURL?: string
   }
@@ -16,7 +16,7 @@ export function withoutQuery(path: string): string {
   return queryIndex === -1 ? path : path.slice(0, queryIndex)
 }
 
-export function createNitroRouteRuleMatcher<TRouteRules extends Record<string, unknown> = Record<string, unknown>>(
+export function createNitroRouteRuleMatcher<TRouteRules extends object = Record<string, unknown>>(
   runtimeConfig: NitroRouteRulesRuntimeConfig<TRouteRules>,
 ): (pathOrUrl: string) => TRouteRules {
   const { nitro, app } = runtimeConfig

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/module.ts
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/module.ts
@@ -7,5 +7,7 @@ export default defineNuxtModule({
   },
   setup(_options, nuxt) {
     setupNitroRuntimeCompatibility(nuxt)
+    nuxt.options.nitro.experimental ||= {}
+    nuxt.options.nitro.experimental.asyncContext = true
   },
 })

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/package.json
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "nitro": "3.0.260610-beta",
-    "nuxt": "npm:nuxt-nightly@5.0.0-29762631.396a4ae3",
+    "nuxt": "npm:nuxt-nightly@5.0.0-29762711.192612c7",
     "nuxtseo-shared": "link:../../..",
     "vue": "^3.5.40",
     "vue-router": "^5.2.0"

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-lock.yaml
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.0)
       nuxt:
-        specifier: npm:nuxt-nightly@5.0.0-29762631.396a4ae3
-        version: nuxt-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
+        specifier: npm:nuxt-nightly@5.0.0-29762711.192612c7
+        version: nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
       nuxtseo-shared:
         specifier: link:../../..
         version: link:../../..
@@ -223,8 +223,8 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@nuxt/cli-nightly@4.0.0-20260802-084627-9d7ce7a':
-    resolution: {integrity: sha512-D4RA87U1mX/6nUIDK8+wg+Mrx9dcNpj7V1T8sO6jYOzx3fDMBBLlxKv0arSrFX/zcoUBYxTMSUBqCOJsTXCWmA==}
+  '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d':
+    resolution: {integrity: sha512-1jFOG9YK0y9U2DndTkYw7Kg7I42FVZUAldVGRyD4mJCIaMJXY3pQqSPJR5WAwnBmk4na/2wNM2gnxaO4jRcShQ==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
@@ -255,8 +255,8 @@ packages:
     peerDependencies:
       vite: ^8.0.14
 
-  '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3':
-    resolution: {integrity: sha512-MKAnjrxS1idNGcp25t9VLIsgUMl6WygZLmsrFPwBJiQlZTNcDyaYZ2KVDzvgFAeN7pC5WML7iIvN7fiGYKkTrg==}
+  '@nuxt/kit-nightly@5.0.0-29762711.192612c7':
+    resolution: {integrity: sha512-HzS/GusXvxxQX1iDYgrCoSKHmyKKSjwhYCwjSPR6ScAPnxwO6A3jOMUY4BB+FplmdXy/3muF64phS4SNicHysg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       dotenv: ^17.4.2
@@ -283,14 +283,14 @@ packages:
     resolution: {integrity: sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==}
     engines: {node: '>=18.12.0'}
 
-  '@nuxt/nitro-server-nightly@5.0.0-29762631.396a4ae3':
-    resolution: {integrity: sha512-Czx3nhn3Blk9a1XpG5nY6H125bst2JjU3LELuoLgqLzjWYsE9DKNvvYPJUAuuwG+J6l1ax1w4b4rMf5s8Ha76g==}
+  '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7':
+    resolution: {integrity: sha512-GgPN8hZjE8Yezk6Zodn5VYYV7CECBlV7VUnj0CUC7RKx7ZhPqG4F06VbZimGYbN0l/gw+C1LvtNGenp9M/dK1A==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       '@babel/plugin-proposal-decorators': ^7.25.0 || ^8.0.0
       '@babel/plugin-syntax-typescript': ^7.25.0 || ^8.0.0
       '@rollup/plugin-babel': ^6.0.0 || ^7.0.0
-      nuxt: npm:nuxt-nightly@5.0.0-29762631.396a4ae3
+      nuxt: npm:nuxt-nightly@5.0.0-29762711.192612c7
     peerDependenciesMeta:
       '@babel/plugin-proposal-decorators':
         optional: true
@@ -299,8 +299,8 @@ packages:
       '@rollup/plugin-babel':
         optional: true
 
-  '@nuxt/schema-nightly@5.0.0-29762631.396a4ae3':
-    resolution: {integrity: sha512-/wl1OVm3WNZSEEbQUTQfVXle3WlwAyDDtbzRxE8uJSG/XeyELod8w7Qg++hxOzAzU4+n0l0+zxTibpOdLGJI4A==}
+  '@nuxt/schema-nightly@5.0.0-29762711.192612c7':
+    resolution: {integrity: sha512-g1sGM55zGqjFc8PLE/L+MZSQ27lKX8D6mrAGoJJTjoT3rVQiJ9tMtZc+ArznZ7GU9VDoyFmD4HSZY7Dxz0Ecmw==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
   '@nuxt/telemetry@2.8.0':
@@ -310,8 +310,8 @@ packages:
     peerDependencies:
       '@nuxt/kit': '>=3.0.0'
 
-  '@nuxt/vite-builder-nightly@5.0.0-29762631.396a4ae3':
-    resolution: {integrity: sha512-/dvdK4mCsER6/oRiP8nxqXyPV7y9dWRDdU/3Ka1AqXFV8bJ34l0W770LvGBag2Gh/8uY7+iCSb0MYlaV1YZoww==}
+  '@nuxt/vite-builder-nightly@5.0.0-29762711.192612c7':
+    resolution: {integrity: sha512-iDIVFk5mrW6QnymfvXDpf89CS/vzebEVymLePx0O+Lq2aUKx+Hb1qSbURkx9v4n5brOuGhd45RS06FD5esoJWw==}
     engines: {node: ^22.18.0 || ^24.11.0 || >=26.0.0}
     peerDependencies:
       '@babel/plugin-proposal-decorators': ^7.25.0 || ^8.0.0
@@ -319,7 +319,7 @@ packages:
       '@vitejs/plugin-vue-jsx': ^5.1.5
       autoprefixer: ^10.4.27
       cssnano: ^7.1.3 || ^8.0.0
-      nuxt: npm:nuxt-nightly@5.0.0-29762631.396a4ae3
+      nuxt: npm:nuxt-nightly@5.0.0-29762711.192612c7
       rollup-plugin-visualizer: ^6.0.0 || ^7.0.1
       vue: ^3.3.4
     peerDependenciesMeta:
@@ -1230,8 +1230,8 @@ packages:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
 
-  nuxt-nightly@5.0.0-29762631.396a4ae3:
-    resolution: {integrity: sha512-H4vDSJwYPZDcH75g38LpIoLI6XicVsLw3bKQ6KlMWJEktWd9CViMPEfRixsYtiNt7/08a/f+aLQFpWIfE00z7w==}
+  nuxt-nightly@5.0.0-29762711.192612c7:
+    resolution: {integrity: sha512-EfeTY3oEc4Nzzr88OGdtNsuZv7yyYJAk1K9H8epTLL0Fn3HS0HWhvWT9C7c9wJqw8UHeRi+AR0LsioUbu5FsnA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
@@ -2112,7 +2112,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nuxt/cli-nightly@4.0.0-20260802-084627-9d7ce7a(@nuxt/schema-nightly@5.0.0-29762631.396a4ae3)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
+  '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.21(cac@7.0.0)(citty@0.2.2)
       '@clack/prompts': 1.7.0
@@ -2142,7 +2142,7 @@ snapshots:
       uqr: 0.1.3
       verkit: 0.3.1
     optionalDependencies:
-      '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29762631.396a4ae3'
+      '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29762711.192612c7'
       jiti: 2.7.0
       oxc-parser: 0.140.0
       rolldown: 1.2.1
@@ -2237,7 +2237,7 @@ snapshots:
       - valibot
       - vue
 
-  '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))':
+  '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))':
     dependencies:
       confbox: 0.2.4
       consola: 3.4.2
@@ -2300,10 +2300,10 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)':
+  '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
+      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
       '@unhead/vue': 3.2.3(@oxc-project/types@0.142.0)(cac@7.0.0)(lightningcss@1.33.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       consola: 3.4.2
@@ -2320,7 +2320,7 @@ snapshots:
       mocked-exports: 0.1.1
       nitro: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.0)
       nostics: 1.2.0
-      nuxt: nuxt-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
       ohash: 2.0.11
       pathe: 2.0.3
       srvx: 0.11.22
@@ -2389,7 +2389,7 @@ snapshots:
       - xml2js
       - zephyr-agent
 
-  '@nuxt/schema-nightly@5.0.0-29762631.396a4ae3':
+  '@nuxt/schema-nightly@5.0.0-29762711.192612c7':
     dependencies:
       '@vue/shared': 3.5.40
       defu: 6.1.7
@@ -2398,18 +2398,18 @@ snapshots:
       pkg-types: 2.3.1
       std-env: 4.2.0
 
-  '@nuxt/telemetry@2.8.0(@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))':
+  '@nuxt/telemetry@2.8.0(@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))':
     dependencies:
-      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
+      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
       citty: 0.2.2
       consola: 3.4.2
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder-nightly@5.0.0-29762631.396a4ae3(@vitejs/devtools@0.4.10)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
+  '@nuxt/vite-builder-nightly@5.0.0-29762711.192612c7(@vitejs/devtools@0.4.10)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
-      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
+      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       clickable-path: 0.0.1
       consola: 3.4.2
@@ -2421,7 +2421,7 @@ snapshots:
       js-tokens: 10.0.0
       knitwork: 1.3.0
       mocked-exports: 0.1.1
-      nuxt: nuxt-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
+      nuxt: nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
       pathe: 2.0.3
       pkg-types: 2.3.1
       rolldown-string: 0.3.1(rolldown@1.2.1)
@@ -3236,16 +3236,16 @@ snapshots:
       path-key: 4.0.0
       unicorn-magic: 0.3.0
 
-  nuxt-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0):
+  nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.5(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(vite@8.2.0)
-      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260802-084627-9d7ce7a(@nuxt/schema-nightly@5.0.0-29762631.396a4ae3)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
+      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
       '@nuxt/devtools': 4.0.0-alpha.9(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
-      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
-      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29762631.396a4ae3(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)'
-      '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29762631.396a4ae3'
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit-nightly@5.0.0-29762631.396a4ae3(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))
-      '@nuxt/vite-builder': '@nuxt/vite-builder-nightly@5.0.0-29762631.396a4ae3(@vitejs/devtools@0.4.10)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762631.396a4ae3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)'
+      '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
+      '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)'
+      '@nuxt/schema': '@nuxt/schema-nightly@5.0.0-29762711.192612c7'
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0)))
+      '@nuxt/vite-builder': '@nuxt/vite-builder-nightly@5.0.0-29762711.192612c7(@vitejs/devtools@0.4.10)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.40(typescript@6.0.3))(yaml@2.9.0)'
       '@unhead/vue': 3.2.3(@oxc-project/types@0.142.0)(cac@7.0.0)(lightningcss@1.33.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-workspace.yaml
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 minimumReleaseAgeExclude:
-  - '@nuxt/kit-nightly@5.0.0-29762631.396a4ae3'
-  - '@nuxt/nitro-server-nightly@5.0.0-29762631.396a4ae3'
-  - '@nuxt/schema-nightly@5.0.0-29762631.396a4ae3'
-  - '@nuxt/vite-builder-nightly@5.0.0-29762631.396a4ae3'
-  - nuxt-nightly@5.0.0-29762631.396a4ae3
+  - '@nuxt/kit-nightly@5.0.0-29762711.192612c7'
+  - '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7'
+  - '@nuxt/schema-nightly@5.0.0-29762711.192612c7'
+  - '@nuxt/vite-builder-nightly@5.0.0-29762711.192612c7'
+  - nuxt-nightly@5.0.0-29762711.192612c7

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/compat.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/compat.get.ts
@@ -1,6 +1,14 @@
-import { useRuntimeConfig } from '#nuxtseo/nitro'
+import { useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
 import { defineEventHandler } from '#nuxtseo/h3'
 
-export default defineEventHandler(() => ({
-  marker: useRuntimeConfig().nitroCompatibilityMarker,
-}))
+function readRequestContextMarker() {
+  return (useEvent().context as Record<string, unknown>).nitroCompatibilityMarker
+}
+
+export default defineEventHandler((event) => {
+  ;(event.context as Record<string, unknown>).nitroCompatibilityMarker = 'nuxt-5-context'
+  return {
+    marker: useRuntimeConfig().nitroCompatibilityMarker,
+    requestContextMarker: readRequestContextMarker(),
+  }
+})

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/test.mjs
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/test.mjs
@@ -45,6 +45,7 @@ try {
   const response = await waitForServer()
   assert.deepEqual(await response.json(), {
     marker: 'nuxt-5',
+    requestContextMarker: 'nuxt-5-context',
   })
 }
 finally {

--- a/packages/shared/test/fixtures/nitro-compat/module.ts
+++ b/packages/shared/test/fixtures/nitro-compat/module.ts
@@ -7,5 +7,7 @@ export default defineNuxtModule({
   },
   setup(_options, nuxt) {
     setupNitroRuntimeCompatibility(nuxt)
+    nuxt.options.nitro.experimental ||= {}
+    nuxt.options.nitro.experimental.asyncContext = true
   },
 })

--- a/packages/shared/test/fixtures/nitro-compat/server/api/compat.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat/server/api/compat.get.ts
@@ -1,6 +1,14 @@
-import { useRuntimeConfig } from '#nuxtseo/nitro'
+import { useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
 import { defineEventHandler } from '#nuxtseo/h3'
 
-export default defineEventHandler(() => ({
-  marker: useRuntimeConfig().nitroCompatibilityMarker,
-}))
+function readRequestContextMarker() {
+  return (useEvent().context as Record<string, unknown>).nitroCompatibilityMarker
+}
+
+export default defineEventHandler((event) => {
+  ;(event.context as Record<string, unknown>).nitroCompatibilityMarker = 'nuxt-4-context'
+  return {
+    marker: useRuntimeConfig().nitroCompatibilityMarker,
+    requestContextMarker: readRequestContextMarker(),
+  }
+})

--- a/packages/shared/test/integration/nitro.test.ts
+++ b/packages/shared/test/integration/nitro.test.ts
@@ -13,6 +13,7 @@ describe('nitro runtime compatibility', () => {
   it('serves a runtime handler through the shared virtual imports', async () => {
     await expect($fetch('/api/compat')).resolves.toEqual({
       marker: 'nuxt-4',
+      requestContextMarker: 'nuxt-4-context',
     })
   })
 })

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -108,6 +108,15 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('useRequest as useEvent')
   })
 
+  it('prevents an older helper from overwriting a newer runtime bridge', () => {
+    getNuxtVersionMock.mockReturnValue('5.0.0')
+    const nuxt = createNuxt() as Nuxt & { [key: symbol]: true | undefined }
+
+    setupNitroRuntimeCompatibility(nuxt)
+
+    expect(nuxt[Symbol.for('nuxtseo:nitro-runtime-compatibility')]).toBe(true)
+  })
+
   it('reasserts the runtime bridge after all modules finish setup', () => {
     getNuxtVersionMock.mockReturnValue('5.0.0')
     const nuxt = createNuxt()
@@ -161,6 +170,32 @@ declare module 'srvx' {
     })).toBe(`declare module 'nitropack' {
   interface NitroRuntimeHooks {
     'build:done': () => void
+  }
+}
+
+declare module 'nitropack/types' {
+  interface NitroRuntimeHooks {
+    'build:done': () => void
+  }
+}`)
+  })
+
+  it('renders module-specific Nitro interfaces and omits empty entries', () => {
+    getNuxtVersionMock.mockReturnValue('5.0.0')
+    const compatibility = setupNitroRuntimeCompatibility(createNuxt())
+
+    expect(renderNitroTypeAugmentations(compatibility, {
+      nitroInterfaces: {
+        NitroApp: '_robots?: RobotsState',
+        PrerenderRoute: '_sitemap?: SitemapUrl',
+        EmptyInterface: '  ',
+      },
+    })).toBe(`declare module 'nitro/types' {
+  interface NitroApp {
+    _robots?: RobotsState
+  }
+  interface PrerenderRoute {
+    _sitemap?: SitemapUrl
   }
 }`)
   })

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderNitroTypeAugmentations, setupNitroRuntimeCompatibility } from '../../src/kit'
 
-const { addTypeTemplateMock, getNuxtVersionMock } = vi.hoisted(() => ({
+const { addTypeTemplateMock, getNuxtVersionMock, hookOnceMock } = vi.hoisted(() => ({
   addTypeTemplateMock: vi.fn(),
   getNuxtVersionMock: vi.fn(),
+  hookOnceMock: vi.fn(),
 }))
 
 vi.mock('@nuxt/kit', async importOriginal => ({
@@ -16,6 +17,9 @@ vi.mock('@nuxt/kit', async importOriginal => ({
 
 function createNuxt(): Nuxt {
   return {
+    hooks: {
+      hookOnce: hookOnceMock,
+    },
     options: {
       nitro: {},
     },
@@ -26,6 +30,7 @@ describe('setupNitroRuntimeCompatibility', () => {
   beforeEach(() => {
     addTypeTemplateMock.mockReset()
     getNuxtVersionMock.mockReset()
+    hookOnceMock.mockReset()
   })
 
   it('registers Nitro 2 runtime virtual module and H3 alias', async () => {
@@ -85,6 +90,20 @@ describe('setupNitroRuntimeCompatibility', () => {
     setupNitroRuntimeCompatibility(nuxt)
 
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
+  })
+
+  it('reasserts the runtime bridge after all modules finish setup', () => {
+    getNuxtVersionMock.mockReturnValue('5.0.0')
+    const nuxt = createNuxt()
+
+    setupNitroRuntimeCompatibility(nuxt)
+    nuxt.options.nitro.virtual!['#nuxtseo/nitro'] = 'stale runtime bridge'
+
+    expect(hookOnceMock).toHaveBeenCalledOnce()
+    const applyCompatibility = hookOnceMock.mock.calls[0]![1]
+    applyCompatibility()
+
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent')
   })
 })
 

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -72,7 +72,7 @@ describe('setupNitroRuntimeCompatibility', () => {
       nitroTypesModule: 'nitro/types',
     })
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('definePlugin as defineNitroPlugin } from \'nitro\'')
-    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRuntimeConfig } from \'nitro/runtime-config\'')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRuntimeConfig(_event)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('getRouteRules')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedHandler as defineCachedEventHandler')
@@ -80,7 +80,8 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
     const template = addTypeTemplateMock.mock.calls[0]![0]
-    await expect(template.getContents()).resolves.toContain('from \'nitro/runtime-config\'')
+    await expect(template.getContents()).resolves.toContain('import(\'nitro/runtime-config\')')
+    await expect(template.getContents()).resolves.toContain('useRuntimeConfig(event?:')
     await expect(template.getContents()).resolves.toContain('defineCachedHandler as defineCachedEventHandler')
     await expect(template.getContents()).resolves.toContain('export * from \'nitro/h3\'')
   })

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -92,6 +92,18 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
   })
 
+  it('registers the request context type bridge after an older helper ran', async () => {
+    getNuxtVersionMock.mockReturnValue('5.0.0')
+    const nuxt = createNuxt() as Nuxt & { [key: symbol]: true }
+    nuxt[Symbol.for('nuxtseo:nitro-runtime-compatibility')] = true
+
+    setupNitroRuntimeCompatibility(nuxt)
+
+    expect(addTypeTemplateMock).toHaveBeenCalledOnce()
+    const template = addTypeTemplateMock.mock.calls[0]![0]
+    await expect(template.getContents()).resolves.toContain('useRequest as useEvent')
+  })
+
   it('reasserts the runtime bridge after all modules finish setup', () => {
     getNuxtVersionMock.mockReturnValue('5.0.0')
     const nuxt = createNuxt()

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -74,11 +74,13 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRuntimeConfig } from \'nitro/runtime-config\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('getRouteRules')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedHandler as defineCachedEventHandler')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
     const template = addTypeTemplateMock.mock.calls[0]![0]
     await expect(template.getContents()).resolves.toContain('from \'nitro/runtime-config\'')
+    await expect(template.getContents()).resolves.toContain('defineCachedHandler as defineCachedEventHandler')
     await expect(template.getContents()).resolves.toContain('export * from \'nitro/h3\'')
   })
 

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -42,6 +42,7 @@ describe('setupNitroRuntimeCompatibility', () => {
       nitroTypesModule: 'nitropack',
     })
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'nitropack/runtime\'')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useEvent')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
@@ -67,7 +68,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('definePlugin as defineNitroPlugin } from \'nitro\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRuntimeConfig } from \'nitro/runtime-config\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('getRouteRules')
-    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('useEvent')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -48,6 +48,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     })
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'nitropack/runtime\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useEvent')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })

--- a/packages/shared/test/unit/server.test.ts
+++ b/packages/shared/test/unit/server.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, expectTypeOf, it } from 'vitest'
 import { createNitroRouteRuleMatcher, normalizeNitroMatchedRouteRules } from '../../src/server'
 
 function rc(routeRules: Record<string, any>, baseURL = '/') {
@@ -6,6 +6,23 @@ function rc(routeRules: Record<string, any>, baseURL = '/') {
 }
 
 describe('createNitroRouteRuleMatcher', () => {
+  it('accepts typed route rules without an index signature', () => {
+    interface RouteRules {
+      redirect?: string
+    }
+
+    const match = createNitroRouteRuleMatcher<RouteRules>({
+      nitro: {
+        routeRules: {
+          '/foo': { redirect: '/x' },
+        },
+      },
+    })
+
+    expectTypeOf(match).returns.toEqualTypeOf<RouteRules>()
+    expect(match('/foo')).toEqual({ redirect: '/x' })
+  })
+
   it('merges overlapping rules with defu precedence, more specific wins', () => {
     const match = createNitroRouteRuleMatcher(rc({
       '/blog/**': { headers: { a: '1' }, redirect: '/generic' },

--- a/packages/shared/test/unit/server.test.ts
+++ b/packages/shared/test/unit/server.test.ts
@@ -1,3 +1,4 @@
+import type { NitroRouteRulesRuntimeConfig } from '../../src/server'
 import { describe, expect, expectTypeOf, it } from 'vitest'
 import { createNitroRouteRuleMatcher, normalizeNitroMatchedRouteRules } from '../../src/server'
 
@@ -21,6 +22,26 @@ describe('createNitroRouteRuleMatcher', () => {
 
     expectTypeOf(match).returns.toEqualTypeOf<RouteRules>()
     expect(match('/foo')).toEqual({ redirect: '/x' })
+  })
+
+  it('decouples the runtime config rule type from the returned module rule view', () => {
+    interface RuntimeRouteRule {
+      redirect?: string
+    }
+    interface ModuleRouteRule {
+      ogImage?: false | { width: number }
+    }
+
+    const runtimeConfig = {
+      nitro: {
+        routeRules: {
+          '/foo': { redirect: '/x' },
+        },
+      },
+    } satisfies NitroRouteRulesRuntimeConfig<RuntimeRouteRule>
+    const match = createNitroRouteRuleMatcher<ModuleRouteRule>(runtimeConfig)
+
+    expectTypeOf(match).returns.toEqualTypeOf<ModuleRouteRule>()
   })
 
   it('merges overlapping rules with defu precedence, more specific wins', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Related to harlan-zw/nuxt-site-config#101

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Normalize Nitro 2 and Nitro 3 runtime APIs behind `#nuxtseo/nitro` and `#nuxtseo/h3`. This covers request context, runtime config, cached handlers, mixed shared-package versions, and typed route-rule matching. Type augmentations target both Nitro 2 entrypoints and support module-specific Nitro interfaces, removing downstream fallback declarations. Unit tests plus live Nuxt 4 and Nuxt 5 fixtures exercise both compatibility paths.
