### PR TITLE
fix(shared): support nuxt-i18n-micro localized routes

### DIFF
--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -20,6 +20,12 @@ export interface AutoI18nConfig {
   pages?: Record<string, Record<string, string | false>>
 }
 
+type I18nPages = NonNullable<AutoI18nConfig['pages']>
+
+interface NuxtI18nMicroOptions extends NuxtI18nOptions {
+  globalLocaleRoutes?: Record<string, I18nPages[string] | boolean>
+}
+
 export interface StrategyProps {
   localeCode: string
   pageLocales: string
@@ -187,6 +193,19 @@ export function resolveI18nModule(): false | I18nModuleResolution {
   }
 }
 
+function resolveI18nPages(config: NuxtI18nOptions, isMicro: boolean): I18nPages | undefined {
+  const routes = isMicro
+    ? (config as NuxtI18nMicroOptions).globalLocaleRoutes
+    : config.pages
+  if (!routes)
+    return undefined
+
+  return Object.fromEntries(
+    Object.entries(routes).filter((entry): entry is [string, I18nPages[string]] =>
+      typeof entry[1] === 'object' && entry[1] !== null && !Array.isArray(entry[1])),
+  )
+}
+
 export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }): Promise<false | AutoI18nConfig> {
   const i18n = resolveI18nModule()
   if (!i18n)
@@ -201,7 +220,8 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
 
   const nuxtI18nConfig = (await getNuxtModuleOptions(i18n.module) || {}) as NuxtI18nOptions
   const normalisedLocales = normalizeLocales(nuxtI18nConfig)
-  const usingI18nPages = Object.keys(nuxtI18nConfig.pages || {}).length
+  const pages = resolveI18nPages(nuxtI18nConfig, i18n.isMicro)
+  const usingI18nPages = Object.keys(pages || {}).length
   const hasI18nConfigForAlternatives = nuxtI18nConfig.differentDomains || usingI18nPages || (nuxtI18nConfig.strategy !== 'no_prefix' && nuxtI18nConfig.locales)
   if (!hasI18nConfigForAlternatives)
     return false
@@ -211,7 +231,7 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
     defaultLocale: nuxtI18nConfig.defaultLocale!,
     locales: normalisedLocales,
     strategy: nuxtI18nConfig.strategy as Strategies,
-    pages: nuxtI18nConfig.pages as Record<string, Record<string, string | false>> | undefined,
+    pages,
   }
 }
 

--- a/packages/shared/test/unit/i18n-config.test.ts
+++ b/packages/shared/test/unit/i18n-config.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mapPathForI18nPages, resolveI18nConfig } from '../../src/i18n'
+
+const nuxtKitMocks = vi.hoisted(() => ({
+  getNuxtModuleVersion: vi.fn(),
+  hasNuxtModule: vi.fn(),
+  hasNuxtModuleCompatibility: vi.fn(),
+}))
+
+const sharedKitMocks = vi.hoisted(() => ({
+  getNuxtModuleOptions: vi.fn(),
+}))
+
+vi.mock('@nuxt/kit', () => nuxtKitMocks)
+vi.mock('../../src/kit', () => sharedKitMocks)
+
+describe('resolveI18nConfig', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    nuxtKitMocks.hasNuxtModule.mockImplementation(module => module === 'nuxt-i18n-micro')
+  })
+
+  it('uses nuxt-i18n-micro global locale routes as pages', async () => {
+    sharedKitMocks.getNuxtModuleOptions.mockResolvedValue({
+      locales: [{ code: 'en' }, { code: 'fr' }, { code: 'de' }],
+      defaultLocale: 'en',
+      strategy: 'prefix_except_default',
+      globalLocaleRoutes: {
+        checkout: { en: '/checkout', fr: '/paiement', de: '/kasse' },
+        about: { en: '/about', fr: '/a-propos', de: '/ueber-uns' },
+        disabled: false,
+        inherited: true,
+      },
+    })
+
+    const config = await resolveI18nConfig()
+
+    expect(config).not.toBe(false)
+    if (!config)
+      return
+    expect(config.pages).toEqual({
+      checkout: { en: '/checkout', fr: '/paiement', de: '/kasse' },
+      about: { en: '/about', fr: '/a-propos', de: '/ueber-uns' },
+    })
+    expect(mapPathForI18nPages('/checkout', config)).toEqual([
+      '/fr/paiement',
+      '/de/kasse',
+    ])
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #596

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`resolveI18nConfig` only read `@nuxtjs/i18n`'s `pages` option, leaving `nuxt-i18n-micro` custom paths out of robots and sitemap output. It now reads `globalLocaleRoutes` for micro and skips boolean route entries. The regression covers `/checkout`, `/fr/paiement`, and `/de/kasse`.