### PR TITLE
feat(shared): add event-aware Nitro fetch

### DIFF
--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -64,9 +64,28 @@ const nitroV2Runtime = `export {
   defineTask,
   runTask,
 } from 'nitropack/runtime'
+export function fetchWithEvent(event, request, options) {
+  return event.$fetch(request, options)
+}
 `
 
-const nitroV3Runtime = `export { definePlugin as defineNitroPlugin } from 'nitro'
+const nitroV2RuntimeTypes = `export {
+  defineNitroPlugin,
+  useNitroApp,
+  useEvent,
+  useRuntimeConfig,
+  defineCachedFunction,
+  defineCachedEventHandler,
+  useStorage,
+  defineTask,
+  runTask,
+} from 'nitropack/runtime'
+export function fetchWithEvent<T>(event: import('h3').H3Event, request: import('ofetch').FetchRequest, options?: import('ofetch').FetchOptions): Promise<T>
+`
+
+const nitroV3Runtime = `import { createFetch } from 'ofetch'
+import { fetchWithEvent as fetchRawWithEvent } from 'nitro/h3'
+export { definePlugin as defineNitroPlugin } from 'nitro'
 export { useNitroApp } from 'nitro/app'
 export { useRequest as useEvent } from 'nitro/context'
 import { useRuntimeConfig as _useRuntimeConfig } from 'nitro/runtime-config'
@@ -74,6 +93,12 @@ export function useRuntimeConfig(_event) { return _useRuntimeConfig() }
 export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
+export function fetchWithEvent(event, request, options) {
+  const localFetch = createFetch({
+    fetch: (input, init) => fetchRawWithEvent(event, input, init),
+  })
+  return localFetch(request, options)
+}
 `
 
 const nitroV3RuntimeTypes = `export { definePlugin as defineNitroPlugin } from 'nitro'
@@ -83,6 +108,7 @@ export function useRuntimeConfig(event?: import('nitro/h3').H3Event): ReturnType
 export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
+export function fetchWithEvent<T>(event: import('nitro/h3').H3Event, request: import('ofetch').FetchRequest, options?: import('ofetch').FetchOptions): Promise<T>
 `
 
 function indent(value: string, spaces: number): string {
@@ -97,7 +123,7 @@ function renderInterface(name: string, contents?: string): string | undefined {
 }
 
 function renderRuntimeDeclarations(compatibility: NitroRuntimeCompatibility): string {
-  const nitroRuntime = compatibility._tag === 'nitro-v3' ? nitroV3RuntimeTypes : nitroV2Runtime
+  const nitroRuntime = compatibility._tag === 'nitro-v3' ? nitroV3RuntimeTypes : nitroV2RuntimeTypes
   const h3Runtime = compatibility._tag === 'nitro-v3'
     ? `export * from 'nitro/h3'\n`
     : `export * from 'h3'\n`

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/package.json
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/package.json
@@ -2,12 +2,13 @@
   "name": "nuxtseo-shared-nitro-compat-nuxt5-fixture",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@11.15.1",
+  "packageManager": "pnpm@11.19.0",
   "scripts": {
-    "test": "nuxt prepare && vue-tsc --noEmit -p .nuxt/tsconfig.server.json && nuxt build && node test.mjs"
+    "test": "nuxt prepare && vue-tsc --noEmit -p .nuxt/tsconfig.server.json && node test.mjs"
   },
   "dependencies": {
     "nitro": "3.0.260610-beta",
+    "nitropack": "npm:nitro@3.0.260610-beta",
     "nuxt": "npm:nuxt-nightly@5.0.0-29762711.192612c7",
     "nuxtseo-shared": "link:../../..",
     "vue": "^3.5.40",

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-lock.yaml
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       nitro:
         specifier: 3.0.260610-beta
         version: 3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.0)
+      nitropack:
+        specifier: npm:nitro@3.0.260610-beta
+        version: nitro@3.0.260610-beta(chokidar@5.0.0)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lru-cache@11.5.2)(vite@8.2.0)
       nuxt:
         specifier: npm:nuxt-nightly@5.0.0-29762711.192612c7
         version: nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0)
@@ -223,8 +226,8 @@ packages:
       '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
       '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
 
-  '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d':
-    resolution: {integrity: sha512-1jFOG9YK0y9U2DndTkYw7Kg7I42FVZUAldVGRyD4mJCIaMJXY3pQqSPJR5WAwnBmk4na/2wNM2gnxaO4jRcShQ==}
+  '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0':
+    resolution: {integrity: sha512-1+JRZ20DMJ48b6oB598aQdMNqtjx/nX0VuFBm9v4xjX2VpKe+hCkbhl1gpnNSRLxDn1EYLvgowd5NO1m9codiA==}
     engines: {node: ^22.19.0 || ^24.11.0 || >=26.0.0}
     hasBin: true
     peerDependencies:
@@ -658,6 +661,11 @@ packages:
 
   '@volar/typescript@2.4.28':
     resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@vue-macros/common@3.1.4':
     resolution: {integrity: sha512-/5Fv+6DgIcM9ajY05ZmKBv+LMX1M9A0X+IUwDRVdt67ciw8OV9bvG2r34p3RiEadlsQybjhKPRKNXDC8Bp23cw==}
@@ -727,6 +735,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  args-tokenizer@0.3.0:
+    resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
   ast-kit@2.2.0:
     resolution: {integrity: sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==}
@@ -1326,9 +1337,6 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
-
-  pnpm-workspace-yaml@1.7.0:
-    resolution: {integrity: sha512-cgjaozHkjWL4H8oKZydEWE4mg31XydK3/1cLKjHvwnFAXutp45yAlMKljpOdZEq4TtLuzYAMvy9j05wRm3aoPw==}
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
@@ -2112,10 +2120,11 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
+  '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)':
     dependencies:
       '@bomb.sh/tab': 0.0.21(cac@7.0.0)(citty@0.2.2)
       '@clack/prompts': 1.7.0
+      args-tokenizer: 0.3.0
       citty: 0.2.2
       clickable-path: 0.0.1
       confbox: 0.2.4
@@ -2130,7 +2139,6 @@ snapshots:
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
-      pnpm-workspace-yaml: 1.7.0
       rc9: 3.0.1
       scule: 1.3.0
       source-map-js: 1.2.1
@@ -2700,11 +2708,13 @@ snapshots:
 
   '@volar/source-map@2.4.28': {}
 
-  '@volar/typescript@2.4.28':
+  '@volar/typescript@2.4.28(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.28
       path-browserify: 1.0.1
       vscode-uri: 3.1.0
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@vue-macros/common@3.1.4(vue@3.5.40(typescript@6.0.3))':
     dependencies:
@@ -2809,6 +2819,8 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.2
+
+  args-tokenizer@0.3.0: {}
 
   ast-kit@2.2.0:
     dependencies:
@@ -3239,7 +3251,7 @@ snapshots:
   nuxt-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(@vitejs/devtools@0.4.10)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(magicast@0.5.4)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue-tsc@3.3.9(typescript@6.0.3))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.5(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.1)(vite@8.2.0)
-      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260802-130027-d05718d(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
+      '@nuxt/cli': '@nuxt/cli-nightly@4.0.0-20260802-153152-e80f9d0(@nuxt/schema-nightly@5.0.0-29762711.192612c7)(cac@7.0.0)(jiti@2.7.0)(oxc-parser@0.140.0)(rolldown@1.2.1)'
       '@nuxt/devtools': 4.0.0-alpha.9(cac@7.0.0)(crossws@0.4.10(srvx@0.11.22))(db0@0.3.4)(devframe@0.7.16(cac@7.0.0)(srvx@0.11.22)(typescript@6.0.3))(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.1)(srvx@0.11.22)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0)(vue@3.5.40(typescript@6.0.3))
       '@nuxt/kit': '@nuxt/kit-nightly@5.0.0-29762711.192612c7(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(magic-string@1.1.0)(mlly@1.8.2)(oxc-parser@0.140.0)(rolldown@1.2.1)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))'
       '@nuxt/nitro-server': '@nuxt/nitro-server-nightly@5.0.0-29762711.192612c7(@oxc-project/types@0.142.0)(cac@7.0.0)(chokidar@5.0.0)(db0@0.3.4)(dotenv@17.4.2)(giget@3.3.1)(jiti@2.7.0)(lightningcss@1.33.0)(mlly@1.8.2)(nuxt-nightly@5.0.0-29762711.192612c7)(ofetch@2.0.0-alpha.3)(oxc-parser@0.140.0)(rolldown@1.2.1)(typescript@6.0.3)(unplugin@3.3.0(rolldown@1.2.1)(vite@8.2.0))(vite@8.2.0)'
@@ -3481,10 +3493,6 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.1
       pathe: 2.0.3
-
-  pnpm-workspace-yaml@1.7.0:
-    dependencies:
-      yaml: 2.9.0
 
   postcss@8.5.25:
     dependencies:
@@ -3841,7 +3849,7 @@ snapshots:
 
   vue-tsc@3.3.9(typescript@6.0.3):
     dependencies:
-      '@volar/typescript': 2.4.28
+      '@volar/typescript': 2.4.28(typescript@6.0.3)
       '@vue/language-core': 3.3.9
       typescript: 6.0.3
 

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/compat.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/compat.get.ts
@@ -1,13 +1,15 @@
-import { useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
+import { fetchWithEvent, useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
 import { defineEventHandler } from '#nuxtseo/h3'
 
 function readRequestContextMarker() {
   return (useEvent().context as Record<string, unknown>).nitroCompatibilityMarker
 }
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   ;(event.context as Record<string, unknown>).nitroCompatibilityMarker = 'nuxt-5-context'
+  const forwarded = await fetchWithEvent<{ requestHeader: string }>(event, '/api/forwarded')
   return {
+    forwardedRequestHeader: forwarded.requestHeader,
     marker: useRuntimeConfig().nitroCompatibilityMarker,
     requestContextMarker: readRequestContextMarker(),
   }

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/forwarded.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/server/api/forwarded.get.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler, getRequestHeader } from '#nuxtseo/h3'
+
+export default defineEventHandler(event => ({
+  requestHeader: getRequestHeader(event, 'x-nuxtseo-test'),
+}))

--- a/packages/shared/test/fixtures/nitro-compat-nuxt5/test.mjs
+++ b/packages/shared/test/fixtures/nitro-compat-nuxt5/test.mjs
@@ -4,6 +4,30 @@ import { once } from 'node:events'
 import { readFile } from 'node:fs/promises'
 import { createServer } from 'node:net'
 
+const fixtureDir = import.meta.dirname
+
+async function run(command, args) {
+  const child = spawn(command, args, {
+    cwd: fixtureDir,
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let output = ''
+  for (const stream of [child.stdout, child.stderr]) {
+    stream.on('data', (chunk) => {
+      const text = chunk.toString()
+      output += text
+      process.stdout.write(text)
+    })
+  }
+  const [exitCode] = await once(child, 'exit')
+  assert.equal(exitCode, 0, `${command} ${args.join(' ')} exited with code ${exitCode}`)
+  return output
+}
+
+const buildOutput = await run('nuxt', ['build'])
+assert.doesNotMatch(buildOutput, /\[UNRESOLVED_IMPORT\]|Could not resolve ['"](?:nitropack\/runtime|h3)['"]/, 'Nuxt 5 build emitted a legacy Nitro import warning')
+
 const portServer = createServer()
 portServer.listen(0, '127.0.0.1')
 await once(portServer, 'listening')
@@ -31,8 +55,16 @@ async function waitForServer() {
       throw new Error(`Nuxt 5 server exited with code ${server.exitCode}`)
 
     const response = await fetch(`${origin}/api/compat`, {
+      headers: {
+        'x-nuxtseo-test': 'nuxt-5-forwarded',
+      },
       signal: AbortSignal.timeout(1_000),
-    }).catch(() => null)
+    }).catch((error) => {
+      // Timeouts and refused connections are expected until the child server is ready.
+      if (error instanceof TypeError || error?.name === 'TimeoutError')
+        return null
+      throw error
+    })
     if (response?.ok)
       return response
 
@@ -44,6 +76,7 @@ async function waitForServer() {
 try {
   const response = await waitForServer()
   assert.deepEqual(await response.json(), {
+    forwardedRequestHeader: 'nuxt-5-forwarded',
     marker: 'nuxt-5',
     requestContextMarker: 'nuxt-5-context',
   })

--- a/packages/shared/test/fixtures/nitro-compat/server/api/compat.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat/server/api/compat.get.ts
@@ -1,13 +1,15 @@
-import { useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
+import { fetchWithEvent, useEvent, useRuntimeConfig } from '#nuxtseo/nitro'
 import { defineEventHandler } from '#nuxtseo/h3'
 
 function readRequestContextMarker() {
   return (useEvent().context as Record<string, unknown>).nitroCompatibilityMarker
 }
 
-export default defineEventHandler((event) => {
+export default defineEventHandler(async (event) => {
   ;(event.context as Record<string, unknown>).nitroCompatibilityMarker = 'nuxt-4-context'
+  const forwarded = await fetchWithEvent<{ requestHeader: string }>(event, '/api/forwarded')
   return {
+    forwardedRequestHeader: forwarded.requestHeader,
     marker: useRuntimeConfig().nitroCompatibilityMarker,
     requestContextMarker: readRequestContextMarker(),
   }

--- a/packages/shared/test/fixtures/nitro-compat/server/api/forwarded.get.ts
+++ b/packages/shared/test/fixtures/nitro-compat/server/api/forwarded.get.ts
@@ -1,0 +1,5 @@
+import { defineEventHandler, getRequestHeader } from '#nuxtseo/h3'
+
+export default defineEventHandler(event => ({
+  requestHeader: getRequestHeader(event, 'x-nuxtseo-test'),
+}))

--- a/packages/shared/test/integration/nitro.test.ts
+++ b/packages/shared/test/integration/nitro.test.ts
@@ -11,7 +11,12 @@ await setup({
 
 describe('nitro runtime compatibility', () => {
   it('serves a runtime handler through the shared virtual imports', async () => {
-    await expect($fetch('/api/compat')).resolves.toEqual({
+    await expect($fetch('/api/compat', {
+      headers: {
+        'x-nuxtseo-test': 'nuxt-4-forwarded',
+      },
+    })).resolves.toEqual({
+      forwardedRequestHeader: 'nuxt-4-forwarded',
       marker: 'nuxt-4',
       requestContextMarker: 'nuxt-4-context',
     })

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -49,6 +49,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'nitropack/runtime\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useEvent')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.$fetch(request, options)')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
@@ -56,6 +57,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     const template = addTypeTemplateMock.mock.calls[0]![0]
     await expect(template.getContents()).resolves.toContain('declare module \'#nuxtseo/nitro\'')
     await expect(template.getContents()).resolves.toContain('from \'nitropack/runtime\'')
+    await expect(template.getContents()).resolves.toContain('export function fetchWithEvent<T>')
   })
 
   it('registers Nitro 3 runtime entrypoints and type targets', async () => {
@@ -76,6 +78,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('getRouteRules')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedHandler as defineCachedEventHandler')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('fetchRawWithEvent(event, input, init)')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
@@ -84,6 +87,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('useRuntimeConfig(event?:')
     await expect(template.getContents()).resolves.toContain('defineCachedHandler as defineCachedEventHandler')
     await expect(template.getContents()).resolves.toContain('export * from \'nitro/h3\'')
+    await expect(template.getContents()).resolves.toContain('export function fetchWithEvent<T>')
   })
 
   it('registers shared templates once when several modules call setup', () => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`#nuxtseo/nitro` had no cross-version equivalent for Nitro 2 `event.$fetch`, so modules needed private adapters and Nitro 3 implementations could lose request headers. This adds a typed `fetchWithEvent` bridge for Nitro 2 and Nitro 3, with Nuxt 4 and Nuxt 5 fixtures that assert header propagation and reject legacy runtime imports.