### PR TITLE
chore(ci): add package size reporting

### DIFF
--- a/.github/actions/package-size-report/action.yml
+++ b/.github/actions/package-size-report/action.yml
@@ -1,0 +1,34 @@
+name: Package Size Report
+description: Compare package exports, Nuxt runtime output, and marginal runtime dependencies between two builds
+
+inputs:
+  base-directory:
+    description: Repository root containing the base build
+    required: true
+  head-directory:
+    description: Repository root containing the pull request build
+    required: true
+  report-path:
+    description: Markdown report destination
+    required: true
+  base-available:
+    description: Whether the base build completed successfully
+    required: false
+    default: 'true'
+  base-label:
+    description: Human readable baseline label
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Generate package size report
+      shell: bash
+      env:
+        PACKAGE_SIZE_BASE_AVAILABLE: ${{ inputs.base-available }}
+        PACKAGE_SIZE_BASE_DIRECTORY: ${{ inputs.base-directory }}
+        PACKAGE_SIZE_BASE_LABEL: ${{ inputs.base-label }}
+        PACKAGE_SIZE_HEAD_DIRECTORY: ${{ inputs.head-directory }}
+        PACKAGE_SIZE_REPORT_PATH: ${{ inputs.report-path }}
+      run: node "$GITHUB_ACTION_PATH/report.mjs"

--- a/.github/actions/package-size-report/report.mjs
+++ b/.github/actions/package-size-report/report.mjs
@@ -1,0 +1,544 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'node:fs'
+import { dirname, extname, relative, resolve, sep } from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+import { gzipSync } from 'node:zlib'
+
+const IGNORED_DIRECTORIES = new Set([
+  '.benchmark',
+  '.claude',
+  '.data',
+  '.git',
+  '.github',
+  '.nuxt',
+  '.output',
+  'coverage',
+  'examples',
+  'fixtures',
+  'node_modules',
+  'playground',
+  'test',
+  'tests',
+])
+const PAYLOAD_EXTENSIONS = new Set(['.cjs', '.css', '.js', '.json', '.mjs', '.node', '.wasm'])
+const GZIP_NOISE_BYTES = 16
+
+function isPayloadFile(path) {
+  return PAYLOAD_EXTENSIONS.has(extname(path)) && !path.endsWith('package.json')
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function cleanLabel(value) {
+  return String(value).replace(/[^\w@/+.:-]/g, '_')
+}
+
+function cleanRange(value) {
+  return String(value).replace(/[^\w@/+.:~^*<>=| -]/g, '_').replaceAll('|', '&#124;')
+}
+
+function formatSize(bytes) {
+  if (bytes < 1000)
+    return `${bytes} B`
+  if (bytes < 1_000_000)
+    return `${(bytes / 1000).toFixed(bytes < 10_000 ? 1 : 0)} kB`
+  return `${(bytes / 1_000_000).toFixed(2)} MB`
+}
+
+function formatDelta(bytes) {
+  if (bytes === 0)
+    return '0 B'
+  return `${bytes > 0 ? '+' : '-'}${formatSize(Math.abs(bytes))}`
+}
+
+function formatPercent(difference, base) {
+  if (base <= 0)
+    return ''
+  const percent = difference / base * 100
+  return ` (${percent > 0 ? '+' : ''}${percent.toFixed(1)}%)`
+}
+
+function walkDirectories(root, visit) {
+  visit(root)
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory() || IGNORED_DIRECTORIES.has(entry.name))
+      continue
+    walkDirectories(resolve(root, entry.name), visit)
+  }
+}
+
+function walkFiles(root) {
+  if (!existsSync(root))
+    return []
+  const files = []
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = resolve(root, entry.name)
+    if (entry.isDirectory() && !IGNORED_DIRECTORIES.has(entry.name))
+      files.push(...walkFiles(path))
+    else if (entry.isFile() && isPayloadFile(path))
+      files.push(path)
+  }
+  return files.sort()
+}
+
+function values(value) {
+  if (typeof value === 'string')
+    return [value]
+  if (Array.isArray(value))
+    return value.flatMap(values)
+  if (value && typeof value === 'object')
+    return Object.values(value).flatMap(values)
+  return []
+}
+
+function referencesDist(packageJson) {
+  const filePatterns = Array.isArray(packageJson.files) ? packageJson.files : []
+  if (filePatterns.some(pattern => pattern === 'dist' || pattern.startsWith('dist/')))
+    return true
+  return values({
+    bin: packageJson.bin,
+    browser: packageJson.browser,
+    exports: packageJson.exports,
+    main: packageJson.main,
+    module: packageJson.module,
+  }).some(path => typeof path === 'string' && /^\.?\/?dist\//.test(path))
+}
+
+function discoverPackages(root) {
+  const packages = []
+  walkDirectories(root, (directory) => {
+    const packagePath = resolve(directory, 'package.json')
+    const distPath = resolve(directory, 'dist')
+    if (!existsSync(packagePath) || !existsSync(distPath) || !referencesDist(readJson(packagePath)))
+      return
+    const packageJson = readJson(packagePath)
+    packages.push({
+      directory,
+      distPath,
+      name: cleanLabel(packageJson.name || relative(root, directory) || 'package'),
+      packageJson,
+      relativeDirectory: relative(root, directory).split(sep).join('/') || '.',
+    })
+  })
+  return packages.sort((a, b) => a.relativeDirectory.localeCompare(b.relativeDirectory))
+}
+
+function measure(files) {
+  return files.reduce((total, path) => {
+    const contents = readFileSync(path)
+    return {
+      gzipSize: total.gzipSize + gzipSync(contents, { level: 9 }).length,
+      size: total.size + contents.length,
+    }
+  }, { gzipSize: 0, size: 0 })
+}
+
+function addMetric(metrics, pkg, id, label, files) {
+  const uniqueFiles = [...new Set(files)].filter(path => existsSync(path) && statSync(path).isFile())
+  if (!uniqueFiles.length)
+    return
+  metrics.set(`${pkg.relativeDirectory}:${id}`, {
+    ...measure(uniqueFiles),
+    id: `${pkg.relativeDirectory}:${id}`,
+    kind: 'output',
+    label: `${pkg.name} · ${label}`,
+  })
+}
+
+function parseVersion(value) {
+  const match = String(value).trim().replace(/^v/, '').match(/^(\d+)(?:\.(\d+))?(?:\.(\d+))?(?:-([0-9a-z.-]+))?/i)
+  if (!match)
+    return null
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2] || 0),
+    patch: Number(match[3] || 0),
+    prerelease: match[4] || '',
+  }
+}
+
+function compareVersions(left, right) {
+  for (const key of ['major', 'minor', 'patch']) {
+    if (left[key] !== right[key])
+      return left[key] > right[key] ? 1 : -1
+  }
+  if (left.prerelease === right.prerelease)
+    return 0
+  if (!left.prerelease)
+    return 1
+  if (!right.prerelease)
+    return -1
+  return left.prerelease.localeCompare(right.prerelease)
+}
+
+function testComparator(version, comparator) {
+  const match = comparator.match(/^(<=|>=|[<>=]|[~^]\s*)?v?(\d+|[x*])(?:\.(\d+|[x*]))?(?:\.(\d+|[x*]))?(?:-([0-9a-z.-]+))?$/i)
+  if (!match)
+    return false
+  const operator = (match[1] || '').trim()
+  const parts = [match[2], match[3], match[4]]
+  if (parts[0] === '*' || parts[0]?.toLowerCase() === 'x')
+    return true
+
+  const targetValue = `${parts.map(part => part && !['x', 'X', '*'].includes(part) ? part : '0').join('.')}${match[5] ? `-${match[5]}` : ''}`
+  const target = parseVersion(targetValue)
+  if (!target)
+    return false
+  const compared = compareVersions(version, target)
+  if (operator === '>=')
+    return compared >= 0
+  if (operator === '>')
+    return compared > 0
+  if (operator === '<=')
+    return compared <= 0
+  if (operator === '<')
+    return compared < 0
+
+  const hasWildcard = parts.some(part => !part || ['x', 'X', '*'].includes(part))
+  if (hasWildcard)
+    return version.major === target.major && (!parts[1] || ['x', 'X', '*'].includes(parts[1]) || version.minor === target.minor)
+  if (operator === '^') {
+    const upper = target.major > 0
+      ? { ...target, major: target.major + 1, minor: 0, patch: 0, prerelease: '' }
+      : target.minor > 0
+        ? { ...target, minor: target.minor + 1, patch: 0, prerelease: '' }
+        : { ...target, patch: target.patch + 1, prerelease: '' }
+    return compared >= 0 && compareVersions(version, upper) < 0
+  }
+  if (operator === '~') {
+    const upper = { ...target, minor: target.minor + 1, patch: 0, prerelease: '' }
+    return compared >= 0 && compareVersions(version, upper) < 0
+  }
+  return compared === 0
+}
+
+export function satisfiesVersion(versionValue, rangeValue) {
+  const version = parseVersion(versionValue)
+  const range = String(rangeValue || '').trim()
+  if (!version || !range || /^(?:catalog|workspace|file|link|npm):/.test(range))
+    return false
+  if (range === '*' || range === 'latest')
+    return true
+  return range.split('||').some((alternative) => {
+    const hyphen = alternative.trim().match(/^(\S+)\s+-\s+(\S+)$/)
+    if (hyphen)
+      return testComparator(version, `>=${hyphen[1]}`) && testComparator(version, `<=${hyphen[2]}`)
+    const comparators = alternative.trim().split(/\s+/).filter(Boolean)
+    return comparators.length > 0 && comparators.every(comparator => testComparator(version, comparator))
+  })
+}
+
+function readCatalog(root) {
+  const workspacePath = resolve(root, 'pnpm-workspace.yaml')
+  if (!existsSync(workspacePath))
+    return new Map()
+  const catalog = new Map()
+  let inCatalog = false
+  for (const line of readFileSync(workspacePath, 'utf8').split(/\r?\n/)) {
+    if (line === 'catalog:') {
+      inCatalog = true
+      continue
+    }
+    if (inCatalog && line && !/^\s/.test(line))
+      break
+    if (!inCatalog)
+      continue
+    if (!line.startsWith('  '))
+      continue
+    const entry = line.slice(2)
+    const separatorIndex = entry.indexOf(': ')
+    if (separatorIndex === -1)
+      continue
+    const rawName = entry.slice(0, separatorIndex)
+    const rawRange = entry.slice(separatorIndex + 2)
+    const name = rawName[0] === rawName.at(-1) && ['\'', '"'].includes(rawName[0])
+      ? rawName.slice(1, -1)
+      : rawName
+    const range = rawRange[0] === rawRange.at(-1) && ['\'', '"'].includes(rawRange[0])
+      ? rawRange.slice(1, -1)
+      : rawRange
+    catalog.set(name, range)
+  }
+  return catalog
+}
+
+function dependencyRange(name, range, catalog) {
+  if (range === 'catalog:')
+    return catalog.get(name) || range
+  return range
+}
+
+function packagePayloadFiles(directory, packageJson) {
+  const paths = []
+  const filePatterns = Array.isArray(packageJson.files) ? packageJson.files : []
+  for (const pattern of filePatterns) {
+    if (typeof pattern !== 'string' || pattern.includes('*'))
+      continue
+    const path = resolve(directory, pattern)
+    if (!existsSync(path))
+      continue
+    paths.push(...(statSync(path).isDirectory() ? walkFiles(path) : isPayloadFile(path) ? [path] : []))
+  }
+  if (paths.length)
+    return [...new Set(paths)]
+
+  const distPath = resolve(directory, 'dist')
+  if (existsSync(distPath))
+    return walkFiles(distPath)
+  return values({ exports: packageJson.exports, main: packageJson.main, module: packageJson.module })
+    .filter(path => typeof path === 'string' && !path.includes('*'))
+    .map(path => resolve(directory, path))
+    .filter(path => existsSync(path) && statSync(path).isFile() && isPayloadFile(path))
+}
+
+function dependencyPackage(pkg, name) {
+  const packagePath = resolve(pkg.directory, 'node_modules', name, 'package.json')
+  if (!existsSync(packagePath))
+    return null
+  const realPackagePath = realpathSync(packagePath)
+  return {
+    directory: dirname(realPackagePath),
+    packageJson: readJson(realPackagePath),
+  }
+}
+
+function nuxtProvider(pkg) {
+  const packagePath = resolve(pkg.directory, 'node_modules/nuxt/package.json')
+  if (!existsSync(packagePath))
+    return null
+  const realPackagePath = realpathSync(packagePath)
+  const packageJson = readJson(realPackagePath)
+  return {
+    dependenciesDirectory: dirname(dirname(realPackagePath)),
+    packageJson,
+  }
+}
+
+function nuxtDependencyVersion(provider, name) {
+  if (!provider?.packageJson.dependencies?.[name])
+    return null
+  const packagePath = resolve(provider.dependenciesDirectory, name, 'package.json')
+  return existsSync(packagePath) ? readJson(realpathSync(packagePath)).version : null
+}
+
+function collectDependencies(pkg, metrics, catalog) {
+  const provider = nuxtProvider(pkg)
+  for (const [name, declaredRange] of Object.entries(pkg.packageJson.dependencies || {}).sort()) {
+    const range = dependencyRange(name, declaredRange, catalog)
+    const dependency = dependencyPackage(pkg, name)
+    const providedVersion = nuxtDependencyVersion(provider, name)
+    const free = Boolean(providedVersion && satisfiesVersion(providedVersion, range))
+    const measured = free || !dependency
+      ? { gzipSize: 0, size: 0 }
+      : measure(packagePayloadFiles(dependency.directory, dependency.packageJson))
+    metrics.set(`${pkg.relativeDirectory}:dependency:${name}`, {
+      ...measured,
+      free,
+      id: `${pkg.relativeDirectory}:dependency:${name}`,
+      kind: 'dependency',
+      label: `${pkg.name} · dependency ${cleanLabel(name)}`,
+      nuxtVersion: provider?.packageJson.version || '',
+      providedVersion: providedVersion || '',
+      range: cleanRange(range),
+      resolvedVersion: dependency?.packageJson.version || '',
+    })
+  }
+}
+
+function exportEntries(packageJson) {
+  const exports = packageJson.exports
+  if (!exports)
+    return []
+  if (typeof exports === 'string' || Array.isArray(exports))
+    return [['.', exports]]
+  if (typeof exports !== 'object')
+    return []
+  const keys = Object.keys(exports)
+  if (!keys.some(key => key.startsWith('.')))
+    return [['.', exports]]
+  return Object.entries(exports)
+}
+
+function firstPayloadTarget(target) {
+  return values(target).find(path => typeof path === 'string'
+    && !path.includes('*')
+    && !/\.d\.[cm]?ts$/.test(path)
+    && isPayloadFile(path))
+}
+
+function packageJsonHasExports(packageJson) {
+  return packageJson.exports !== undefined
+}
+
+function collectPackageMetrics(pkg, metrics) {
+  for (const [exportName, target] of exportEntries(pkg.packageJson)) {
+    const path = firstPayloadTarget(target)
+    if (path)
+      addMetric(metrics, pkg, `export:${exportName}`, `export ${cleanLabel(exportName)}`, [resolve(pkg.directory, path)])
+  }
+
+  if (!packageJsonHasExports(pkg.packageJson)) {
+    const main = firstPayloadTarget(pkg.packageJson.module) || firstPayloadTarget(pkg.packageJson.main)
+    if (main)
+      addMetric(metrics, pkg, 'entry', 'entry', [resolve(pkg.directory, main)])
+  }
+
+  const runtimeGroups = [
+    ['runtime:app', 'app runtime', resolve(pkg.distPath, 'runtime/app')],
+    ['runtime:server', 'server runtime', resolve(pkg.distPath, 'runtime/server')],
+    ['runtime:shared', 'shared runtime', resolve(pkg.distPath, 'runtime/shared')],
+  ]
+  for (const [id, label, path] of runtimeGroups)
+    addMetric(metrics, pkg, id, label, walkFiles(path))
+
+  addMetric(metrics, pkg, 'payload', 'published payload', walkFiles(pkg.distPath))
+}
+
+export function collectSnapshot(root) {
+  const absoluteRoot = resolve(root)
+  if (!existsSync(absoluteRoot))
+    throw new Error(`Repository directory does not exist: ${absoluteRoot}`)
+  const metrics = new Map()
+  const catalog = readCatalog(absoluteRoot)
+  for (const pkg of discoverPackages(absoluteRoot)) {
+    collectPackageMetrics(pkg, metrics)
+    collectDependencies(pkg, metrics, catalog)
+  }
+  return metrics
+}
+
+function statusOf(base, head) {
+  if (!base && head?.kind === 'dependency' && head.free)
+    return 'same'
+  if (!base)
+    return 'new'
+  if (!head && base.kind === 'dependency' && base.free)
+    return 'same'
+  if (!head)
+    return 'removed'
+  const difference = head.gzipSize - base.gzipSize
+  if (Math.abs(difference) < GZIP_NOISE_BYTES)
+    return 'same'
+  return difference > 0 ? 'grew' : 'shrank'
+}
+
+function markerOf(status) {
+  return {
+    grew: '🔴',
+    new: '🆕',
+    removed: '🟢',
+    same: '✅',
+    shrank: '🟢',
+  }[status]
+}
+
+function deltaCell(base, head, status) {
+  if (status === 'new')
+    return '🆕 new'
+  if (status === 'removed')
+    return '🟢 removed'
+  if (status === 'same')
+    return '—'
+  const difference = head.gzipSize - base.gzipSize
+  return `${markerOf(status)} ${formatDelta(difference)}${formatPercent(difference, base.gzipSize)}`
+}
+
+export function renderReport(base, head, baseLabel = '') {
+  const ids = [...new Set([...base.keys(), ...head.keys()])].sort()
+  const rows = ids.map(id => ({
+    base: base.get(id),
+    head: head.get(id),
+    id,
+    label: head.get(id)?.label || base.get(id)?.label || id,
+    status: statusOf(base.get(id), head.get(id)),
+  }))
+  const sizeRows = rows.filter(row => row.head?.kind !== 'dependency' || !row.head.free || (row.base && !row.base.free))
+  const changed = sizeRows.filter(row => row.status !== 'same')
+  const grew = changed.filter(row => row.status === 'grew')
+  const smaller = changed.filter(row => row.status === 'shrank' || row.status === 'removed')
+  const added = changed.filter(row => row.status === 'new')
+
+  const verdict = []
+  if (grew.length)
+    verdict.push(`⚠️ **${grew.length} size metric${grew.length === 1 ? '' : 's'} grew**`)
+  else if (smaller.length)
+    verdict.push(`🟢 **${smaller.length} size metric${smaller.length === 1 ? '' : 's'} smaller**`)
+  else
+    verdict.push('✅ **No notable size changes**')
+  if (added.length)
+    verdict.push(`🆕 ${added.length} new metric${added.length === 1 ? '' : 's'} tracked`)
+
+  const output = ['### 📦 Package Size', '', verdict.join(' · ')]
+  if (changed.length) {
+    output.push('', '| Package output | Gzipped | Δ |', '|---|---:|---:|')
+    for (const row of changed) {
+      const before = row.base ? formatSize(row.base.gzipSize) : '—'
+      const after = row.head ? formatSize(row.head.gzipSize) : '—'
+      output.push(`| **${row.label}** | ${before} → ${after} | ${deltaCell(row.base, row.head, row.status)} |`)
+    }
+  }
+
+  output.push(
+    '',
+    `<details><summary>All tracked output (${sizeRows.length})</summary>`,
+    '',
+    '| Package output | Gzipped | Raw | |',
+    '|---|---:|---:|---:|',
+  )
+  for (const row of sizeRows) {
+    const value = row.head || row.base
+    output.push(`| ${row.label} | ${formatSize(value.gzipSize)} | ${formatSize(value.size)} | ${markerOf(row.status)} |`)
+  }
+  output.push('', '</details>')
+
+  const dependencies = rows.filter(row => row.head?.kind === 'dependency')
+  if (dependencies.length) {
+    output.push(
+      '',
+      `<details><summary>Runtime dependencies (${dependencies.length})</summary>`,
+      '',
+      '| Package | Dependency | Requested | Resolved | Cost |',
+      '|---|---|---:|---:|---|',
+    )
+    for (const row of dependencies) {
+      const dependency = row.head
+      const name = dependency.label.replace(' · dependency ', ' | ')
+      const cost = dependency.free
+        ? `♻️ free via Nuxt ${cleanLabel(dependency.nuxtVersion)}`
+        : dependency.providedVersion
+          ? `📦 ${formatSize(dependency.gzipSize)} gzip, Nuxt has ${cleanLabel(dependency.providedVersion)}`
+          : `📦 ${formatSize(dependency.gzipSize)} gzip`
+      output.push(`| ${name} | ${dependency.range} | ${cleanLabel(dependency.resolvedVersion || 'unresolved')} | ${cost} |`)
+    }
+    output.push('', '</details>')
+  }
+
+  if (baseLabel)
+    output.push('', `<sub>Baseline: ${cleanLabel(baseLabel)} · gzip is the comparison metric · changes below ${GZIP_NOISE_BYTES} B gzip are ignored</sub>`)
+  return `${output.join('\n')}\n`
+}
+
+function run() {
+  const baseDirectory = process.env.PACKAGE_SIZE_BASE_DIRECTORY
+  const headDirectory = process.env.PACKAGE_SIZE_HEAD_DIRECTORY
+  const reportPath = process.env.PACKAGE_SIZE_REPORT_PATH
+  if (!baseDirectory || !headDirectory || !reportPath)
+    throw new Error('PACKAGE_SIZE_BASE_DIRECTORY, PACKAGE_SIZE_HEAD_DIRECTORY, and PACKAGE_SIZE_REPORT_PATH are required')
+
+  const base = process.env.PACKAGE_SIZE_BASE_AVAILABLE === 'false'
+    ? new Map()
+    : collectSnapshot(baseDirectory)
+  const head = collectSnapshot(headDirectory)
+  if (!head.size)
+    throw new Error('No published dist output found in the pull request build')
+
+  const report = renderReport(base, head, process.env.PACKAGE_SIZE_BASE_LABEL)
+  mkdirSync(dirname(resolve(reportPath)), { recursive: true })
+  writeFileSync(resolve(reportPath), report, 'utf8')
+  process.stdout.write(report)
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]))
+  run()

--- a/.github/actions/package-size-report/report.test.mjs
+++ b/.github/actions/package-size-report/report.test.mjs
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+// This action must remain dependency-free so consumer repositories can run it.
+// eslint-disable-next-line test/no-import-node-test
+import { after, it } from 'node:test'
+import { collectSnapshot, renderReport, satisfiesVersion } from './report.mjs'
+
+const temporaryDirectories = []
+
+after(() => {
+  for (const directory of temporaryDirectories)
+    rmSync(directory, { force: true, recursive: true })
+})
+
+function makeRepository(files) {
+  const root = mkdtempSync(resolve(tmpdir(), 'package-size-report-'))
+  temporaryDirectories.push(root)
+  const packageDirectory = resolve(root, 'packages/module')
+  mkdirSync(resolve(packageDirectory, 'dist/runtime/app'), { recursive: true })
+  mkdirSync(resolve(packageDirectory, 'dist/runtime/server'), { recursive: true })
+  writeFileSync(resolve(packageDirectory, 'package.json'), JSON.stringify({
+    dependencies: {
+      'ofetch': '^1.5.0',
+      'paid-dep': '^2.0.0',
+    },
+    exports: {
+      '.': {
+        default: './dist/module.mjs',
+        types: './dist/types.d.mts',
+      },
+    },
+    files: ['dist'],
+    name: '@example/module',
+  }))
+  mkdirSync(resolve(packageDirectory, 'node_modules/nuxt'), { recursive: true })
+  mkdirSync(resolve(packageDirectory, 'node_modules/ofetch/dist'), { recursive: true })
+  mkdirSync(resolve(packageDirectory, 'node_modules/paid-dep/dist'), { recursive: true })
+  writeFileSync(resolve(packageDirectory, 'node_modules/nuxt/package.json'), JSON.stringify({
+    dependencies: { ofetch: '^1.5.0' },
+    version: '4.5.1',
+  }))
+  writeFileSync(resolve(packageDirectory, 'node_modules/ofetch/package.json'), JSON.stringify({
+    files: ['dist'],
+    version: '1.5.1',
+  }))
+  writeFileSync(resolve(packageDirectory, 'node_modules/ofetch/dist/index.mjs'), 'export const fetch = true\n')
+  writeFileSync(resolve(packageDirectory, 'node_modules/paid-dep/package.json'), JSON.stringify({
+    files: ['dist'],
+    version: '2.1.0',
+  }))
+  writeFileSync(resolve(packageDirectory, 'node_modules/paid-dep/dist/index.mjs'), 'export const paid = true\n')
+  for (const [path, contents] of Object.entries(files))
+    writeFileSync(resolve(packageDirectory, path), contents)
+  return root
+}
+
+it('collects exports, runtime groups, and published payload', () => {
+  const repository = makeRepository({
+    'dist/module.mjs': 'export default 1\n',
+    'dist/runtime/app/plugin.js': 'export const app = true\n',
+    'dist/runtime/server/handler.js': 'export const server = true\n',
+  })
+  const snapshot = collectSnapshot(repository)
+
+  assert.deepEqual([...snapshot.keys()], [
+    'packages/module:export:.',
+    'packages/module:runtime:app',
+    'packages/module:runtime:server',
+    'packages/module:payload',
+    'packages/module:dependency:ofetch',
+    'packages/module:dependency:paid-dep',
+  ])
+  assert.equal(snapshot.get('packages/module:dependency:ofetch').free, true)
+  assert.equal(snapshot.get('packages/module:dependency:paid-dep').free, false)
+})
+
+it('reports growth and removed output against the base build', () => {
+  const largerModule = Array.from({ length: 100 }, (_, index) => `export const value${index} = ${index}\n`).join('')
+  const largerRuntime = Array.from({ length: 100 }, (_, index) => `export const appValue${index} = ${index}\n`).join('')
+  const baseRepository = makeRepository({
+    'dist/module.mjs': 'export default 1\n',
+    'dist/runtime/app/plugin.js': 'export const app = true\n',
+    'dist/runtime/server/handler.js': 'export const server = true\n',
+  })
+  const headRepository = makeRepository({
+    'dist/module.mjs': largerModule,
+    'dist/runtime/app/plugin.js': largerRuntime,
+  })
+
+  const report = renderReport(
+    collectSnapshot(baseRepository),
+    collectSnapshot(headRepository),
+    'main @ abc123',
+  )
+
+  assert.match(report, /^### 📦 Package Size/)
+  assert.match(report, /size metrics grew/)
+  assert.match(report, /server runtime.+removed/)
+  assert.match(report, /Baseline: main_@_abc123/)
+  assert.match(report, /free via Nuxt 4.5.1/)
+  assert.match(report, /paid-dep.+2.1.0.+📦/)
+})
+
+it('matches common Nuxt dependency semver ranges', () => {
+  assert.equal(satisfiesVersion('4.5.1', '^3.16.0 || ^4.0.0 || ^5.0.0'), true)
+  assert.equal(satisfiesVersion('1.5.1', '^1.5.0'), true)
+  assert.equal(satisfiesVersion('2.0.0', '^1.5.0'), false)
+  assert.equal(satisfiesVersion('3.5.40', '>=3.5.0 <4.0.0'), true)
+  assert.equal(satisfiesVersion('4.0.0-alpha.7', '4.0.0-alpha.7'), true)
+  assert.equal(satisfiesVersion('4.5.1', 'catalog:'), false)
+})
+
+it('ignores repositories without published dist metadata', () => {
+  const root = mkdtempSync(resolve(tmpdir(), 'package-size-report-'))
+  temporaryDirectories.push(root)
+  mkdirSync(resolve(root, 'dist'), { recursive: true })
+  writeFileSync(resolve(root, 'package.json'), JSON.stringify({ private: true }))
+  writeFileSync(resolve(root, 'dist/stale.mjs'), 'export {}\n')
+
+  assert.equal(collectSnapshot(root).size, 0)
+})

--- a/.github/workflows/package-size-comment.yml
+++ b/.github/workflows/package-size-comment.yml
@@ -1,0 +1,24 @@
+name: Package Size Comment
+
+on:
+  workflow_run:
+    workflows:
+      - Package Size Analysis
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      pull-requests: write
+    uses: ./.github/workflows/reusable-package-size-comment.yml

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,18 @@
+name: Package Size Analysis
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/README.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    uses: ./.github/workflows/reusable-package-size.yml

--- a/.github/workflows/reusable-package-size-comment.yml
+++ b/.github/workflows/reusable-package-size-comment.yml
@@ -1,0 +1,117 @@
+name: Reusable Package Size Comment
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  comment:
+    permissions:
+      actions: read
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Resolve pull request
+        id: pull-request
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const run = context.payload.workflow_run
+            const headOwner = run.head_repository?.owner?.login
+            if (!headOwner || !run.head_branch) {
+              core.setFailed('The workflow run is missing its head repository or branch')
+              return
+            }
+
+            const { data: pullRequests } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${headOwner}:${run.head_branch}`,
+              per_page: 100,
+            })
+            const expectedHeadRepository = run.head_repository.full_name
+            const expectedBaseRepository = `${context.repo.owner}/${context.repo.repo}`
+            const matches = pullRequests.filter(pullRequest =>
+              pullRequest.state === 'open'
+              && pullRequest.head.sha === run.head_sha
+              && pullRequest.head.repo?.full_name === expectedHeadRepository
+              && pullRequest.base.repo.full_name === expectedBaseRepository,
+            )
+
+            if (matches.length !== 1) {
+              core.setFailed(`Expected one open pull request for ${run.head_sha}, found ${matches.length}`)
+              return
+            }
+
+            core.setOutput('number', matches[0].number)
+
+      - name: Download package size report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: package-size-report
+          path: ${{ runner.temp }}/package-size-report
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Validate package size report
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/package-size-comment.md
+          EXPECTED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          EXPECTED_PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+          REPORT_DIR: ${{ runner.temp }}/package-size-report
+        run: |
+          report="$REPORT_DIR/report.md"
+          pr_number="$REPORT_DIR/pr-number.txt"
+          head_sha="$REPORT_DIR/head-sha.txt"
+
+          for file in "$report" "$pr_number" "$head_sha"; do
+            if [ ! -f "$file" ] || [ -L "$file" ]; then
+              echo "::error::Missing or invalid report file: $file"
+              exit 1
+            fi
+          done
+
+          if [ "$(wc -c < "$pr_number")" -gt 16 ] || [ "$(wc -c < "$head_sha")" -gt 64 ]; then
+            echo "::error::Artifact metadata is too large"
+            exit 1
+          fi
+
+          artifact_pr_number=$(tr -d '\r\n' < "$pr_number")
+          if ! echo "$artifact_pr_number" | grep -Eq '^[0-9]+$' \
+            || [ "$artifact_pr_number" != "$EXPECTED_PR_NUMBER" ]; then
+            echo "::error::Artifact pull request number does not match the workflow run"
+            exit 1
+          fi
+
+          if [ "$(tr -d '\r\n' < "$head_sha")" != "$EXPECTED_HEAD_SHA" ]; then
+            echo "::error::Artifact head SHA does not match the workflow run"
+            exit 1
+          fi
+
+          report_size=$(wc -c < "$report")
+          if [ "$report_size" -lt 1 ] || [ "$report_size" -gt 131072 ]; then
+            echo "::error::Package size report must be between 1 byte and 128 KiB"
+            exit 1
+          fi
+
+          if [ "$(head -n 1 "$report")" != '### 📦 Package Size' ]; then
+            echo "::error::Package size report has an unexpected format"
+            exit 1
+          fi
+
+          if [ -e "$COMMENT_PATH" ] || [ -L "$COMMENT_PATH" ]; then
+            echo "::error::Refusing to overwrite the validated comment path"
+            exit 1
+          fi
+          sed 's/@/@<!-- -->/g' "$report" > "$COMMENT_PATH"
+
+      - name: Post comment on pull request
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          header: Package Size Analysis
+          number: ${{ steps.pull-request.outputs.number }}
+          path: ${{ runner.temp }}/package-size-comment.md
+          skip_unchanged: true

--- a/.github/workflows/reusable-package-size.yml
+++ b/.github/workflows/reusable-package-size.yml
@@ -18,7 +18,7 @@ on:
       prepare-command:
         description: Optional command to run before each build
         type: string
-        default: ''
+        default: pnpm dev:prepare
       build-command:
         description: Package build command
         type: string

--- a/.github/workflows/reusable-package-size.yml
+++ b/.github/workflows/reusable-package-size.yml
@@ -1,0 +1,109 @@
+name: Reusable Package Size
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        description: Runner to use
+        type: string
+        default: ubuntu-24.04-arm
+      node-version:
+        description: Node.js version
+        type: string
+        default: 'lts/*'
+      install-command:
+        description: Dependency installation command
+        type: string
+        default: pnpm i --trust-lockfile
+      prepare-command:
+        description: Optional command to run before each build
+        type: string
+        default: ''
+      build-command:
+        description: Package build command
+        type: string
+        default: pnpm build
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check out base commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          path: .benchmark/base
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Use Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: pnpm
+
+      - name: Build base commit
+        id: base-build
+        continue-on-error: true
+        working-directory: .benchmark/base
+        run: |
+          ${{ inputs.install-command }}
+          ${{ inputs.prepare-command }}
+          ${{ inputs.build-command }}
+
+      - name: Warn when the base build is unavailable
+        if: ${{ steps.base-build.outcome != 'success' }}
+        run: echo "::warning::The base build failed; pull request output will be reported as new."
+
+      - name: Build pull request
+        run: |
+          ${{ inputs.install-command }}
+          ${{ inputs.prepare-command }}
+          ${{ inputs.build-command }}
+
+      - name: Resolve baseline label
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          short_sha=$(git rev-parse --short "$BASE_SHA")
+          date=$(git show -s --format=%cs "$BASE_SHA")
+          echo "BASE_LABEL=$BASE_REF @ $short_sha · $date" >> "$GITHUB_ENV"
+
+      - name: Generate package size report
+        uses: ./.github/actions/package-size-report
+        with:
+          base-available: ${{ steps.base-build.outcome == 'success' }}
+          base-directory: ${{ github.workspace }}/.benchmark/base
+          base-label: ${{ env.BASE_LABEL }}
+          head-directory: ${{ github.workspace }}
+          report-path: ${{ runner.temp }}/package-size-report/report.md
+
+      - name: Prepare package size artifact
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPORT_DIR: ${{ runner.temp }}/package-size-report
+        run: |
+          cat "$REPORT_DIR/report.md" >> "$GITHUB_STEP_SUMMARY"
+          printf '%s\n' "$PR_NUMBER" > "$REPORT_DIR/pr-number.txt"
+          printf '%s\n' "$HEAD_SHA" > "$REPORT_DIR/head-sha.txt"
+
+      - name: Upload package size report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: package-size-report
+          path: ${{ runner.temp }}/package-size-report
+          if-no-files-found: error
+          retention-days: 1

--- a/scripts/sync-workflows.mjs
+++ b/scripts/sync-workflows.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 import { execSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import process from 'node:process'
 
 const HOME_RE = /^~/
 const ROOT = dirname(new URL(import.meta.url).pathname)
+const ACTIONS_DIR = resolve(ROOT, '..', '.github', 'actions')
 const WORKFLOWS_DIR = resolve(ROOT, 'workflows')
 
 // Module repos relative to ~/pkg
@@ -20,7 +21,14 @@ const MODULES = [
 ]
 
 // Files that are identical across all modules (synced as-is)
-const SHARED_FILES = ['test.yml', 'nightly.yml', 'deploy-docs.yml']
+const SHARED_FILES = [
+  'test.yml',
+  'nightly.yml',
+  'deploy-docs.yml',
+  'package-size.yml',
+  'package-size-comment.yml',
+]
+const SHARED_ACTIONS = ['package-size-report']
 
 // Release template, `{{MONOREPO_WITH}}` is replaced per module
 const RELEASE_TEMPLATE = `name: Release
@@ -65,6 +73,14 @@ function syncModule(mod) {
     console.log(`  ${file}`)
   }
 
+  for (const action of SHARED_ACTIONS) {
+    const src = resolve(ACTIONS_DIR, action)
+    const destination = resolve(target, '.github', 'actions', action)
+    mkdirSync(dirname(destination), { recursive: true })
+    cpSync(src, destination, { force: true, recursive: true })
+    console.log(`  actions/${action}`)
+  }
+
   // Generate release.yml
   const monorepoWith = mod.monorepo
     ? '\n    with:\n      monorepo: true'
@@ -77,7 +93,8 @@ function syncModule(mod) {
 // Shared workflow files that get copied to modules (not the reusable-* ones)
 // We need to create these canonical files in .github/workflows/ if they don't exist as sync sources
 const sharedSources = SHARED_FILES.map(f => resolve(WORKFLOWS_DIR, f))
-const missing = sharedSources.filter(f => !existsSync(f))
+const sharedActionSources = SHARED_ACTIONS.map(action => resolve(ACTIONS_DIR, action, 'action.yml'))
+const missing = [...sharedSources, ...sharedActionSources].filter(f => !existsSync(f))
 if (missing.length) {
   console.error('Missing source workflow files:', missing)
   process.exit(1)

--- a/scripts/workflows/package-size-comment.yml
+++ b/scripts/workflows/package-size-comment.yml
@@ -1,0 +1,24 @@
+name: Package Size Comment
+
+on:
+  workflow_run:
+    workflows:
+      - Package Size Analysis
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  comment:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      pull-requests: write
+    uses: harlan-zw/nuxt-seo/.github/workflows/reusable-package-size-comment.yml@main

--- a/scripts/workflows/package-size.yml
+++ b/scripts/workflows/package-size.yml
@@ -1,0 +1,18 @@
+name: Package Size Analysis
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/README.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    uses: harlan-zw/nuxt-seo/.github/workflows/reusable-package-size.yml@main


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [ ] 🐞 Bug fix
- [ ] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds the shared `package-size-report` action and fork-safe workflows that compare base and pull request builds. Reports cover package exports, published payloads, Nuxt app and server runtime output, plus dependency cost. A dependency counts as free only when Nuxt's resolved version satisfies the module's semver range.

The workflow runs directly in `nuxt-seo`, covering `@nuxtjs/seo`, `nuxtseo-shared`, and `nuxtseo-telemetry`. `sync-workflows.mjs` copies the same action and caller workflows to the module repositories.
