### PR TITLE
fix(shared): scope Nitro 3 ofetch alias

### DIFF
--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -1,5 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
-import { addTypeTemplate, getNuxtVersion, useNuxt } from '@nuxt/kit'
+import { addTypeTemplate, getNuxtVersion, resolveModule, useNuxt } from '@nuxt/kit'
 
 export type NitroRuntimeCompatibility
   = | {
@@ -27,6 +27,7 @@ export interface NitroTypeAugmentations {
 
 const NITRO_RUNTIME_MODULE = '#nuxtseo/nitro'
 const H3_RUNTIME_MODULE = '#nuxtseo/h3'
+const OFETCH_RUNTIME_MODULE = '#nuxtseo/ofetch'
 const TYPE_TEMPLATE_FILENAME = 'types/nuxtseo-nitro.d.ts'
 const legacySetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility')
 const typeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:request-context-types')
@@ -83,7 +84,7 @@ const nitroV2RuntimeTypes = `export {
 export function fetchWithEvent<T>(event: import('h3').H3Event, request: import('ofetch').FetchRequest, options?: import('ofetch').FetchOptions): Promise<T>
 `
 
-const nitroV3Runtime = `import { createFetch } from 'ofetch'
+const nitroV3Runtime = `import { createFetch } from '${OFETCH_RUNTIME_MODULE}'
 import { fetchWithEvent as fetchRawWithEvent } from 'nitro/h3'
 export { definePlugin as defineNitroPlugin } from 'nitro'
 export { useNitroApp } from 'nitro/app'
@@ -144,6 +145,8 @@ function applyNitroRuntimeCompatibility(nuxt: Nuxt, compatibility: NitroRuntimeC
   nitroOptions.alias ||= {}
   nitroOptions.virtual ||= {}
   nitroOptions.alias[H3_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
+  if (compatibility._tag === 'nitro-v3')
+    nitroOptions.alias[OFETCH_RUNTIME_MODULE] = resolveModule('ofetch', { url: new URL(import.meta.url) })
   nitroOptions.virtual[NITRO_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime
 }
 

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -3,16 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderNitroTypeAugmentations, setupNitroRuntimeCompatibility } from '../../src/kit'
 
-const { addTypeTemplateMock, getNuxtVersionMock, hookOnceMock } = vi.hoisted(() => ({
+const { addTypeTemplateMock, getNuxtVersionMock, hookOnceMock, resolveModuleMock } = vi.hoisted(() => ({
   addTypeTemplateMock: vi.fn(),
   getNuxtVersionMock: vi.fn(),
   hookOnceMock: vi.fn(),
+  resolveModuleMock: vi.fn(),
 }))
 
 vi.mock('@nuxt/kit', async importOriginal => ({
   ...await importOriginal<typeof import('@nuxt/kit')>(),
   addTypeTemplate: addTypeTemplateMock,
   getNuxtVersion: getNuxtVersionMock,
+  resolveModule: resolveModuleMock,
 }))
 
 function createNuxt(): Nuxt {
@@ -31,6 +33,8 @@ describe('setupNitroRuntimeCompatibility', () => {
     addTypeTemplateMock.mockReset()
     getNuxtVersionMock.mockReset()
     hookOnceMock.mockReset()
+    resolveModuleMock.mockReset()
+    resolveModuleMock.mockReturnValue('/resolved/ofetch.mjs')
   })
 
   it('registers Nitro 2 runtime virtual module and H3 alias', async () => {
@@ -51,6 +55,8 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.$fetch(request, options)')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBeUndefined()
+    expect(resolveModuleMock).not.toHaveBeenCalled()
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
@@ -79,7 +85,10 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedHandler as defineCachedEventHandler')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('fetchRawWithEvent(event, input, init)')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'#nuxtseo/ofetch\'')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
+    expect(resolveModuleMock).toHaveBeenCalledWith('ofetch', { url: expect.any(URL) })
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
     const template = addTypeTemplateMock.mock.calls[0]![0]


### PR DESCRIPTION
## Summary

Resolve `ofetch` once inside the shared Nitro 3 compatibility helper and expose it through the private `#nuxtseo/ofetch` alias.

This keeps the fetch bridge resolvable under pnpm without applying a global `ofetch` alias to every consuming module. Nitro 2 remains unchanged.

## Verification

- 112 shared tests pass
- Nuxt 5 compatibility fixture builds and runs
- shared typecheck passes
- shared build passes
