### PR TITLE
fix: support Nitro 3 internal raw fetches

### DIFF
--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -68,6 +68,9 @@ const nitroV2Runtime = `export {
 export function fetchWithEvent(event, request, options) {
   return event.$fetch(request, options)
 }
+export function fetchRawWithEvent(event, request, init) {
+  return event.fetch(request, init)
+}
 `
 
 const nitroV2RuntimeTypes = `export {
@@ -82,10 +85,12 @@ const nitroV2RuntimeTypes = `export {
   runTask,
 } from 'nitropack/runtime'
 export function fetchWithEvent<T>(event: import('h3').H3Event, request: import('ofetch').FetchRequest, options?: import('ofetch').FetchOptions): Promise<T>
+export function fetchRawWithEvent(event: import('h3').H3Event, request: RequestInfo | URL, init?: RequestInit): Promise<Response>
 `
 
 const nitroV3Runtime = `import { createFetch } from '${OFETCH_RUNTIME_MODULE}'
-import { fetchWithEvent as fetchRawWithEvent } from 'nitro/h3'
+import { fetchWithEvent as fetchH3WithEvent, getProxyRequestHeaders } from 'nitro/h3'
+import { useNitroApp as _useNitroApp } from 'nitro/app'
 export { definePlugin as defineNitroPlugin } from 'nitro'
 export { useNitroApp } from 'nitro/app'
 export { useRequest as useEvent } from 'nitro/context'
@@ -94,9 +99,24 @@ export function useRuntimeConfig(_event) { return _useRuntimeConfig() }
 export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler } from 'nitro/cache'
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
+function fetchRaw(event, input, init) {
+  if (typeof input !== 'string' || !input.startsWith('/'))
+    return fetchH3WithEvent(event, input, init)
+  const headers = new Headers(getProxyRequestHeaders(event, { host: true }))
+  for (const [name, value] of new Headers(init?.headers))
+    headers.set(name, value)
+  const request = new Request(new URL(input, event.url), { ...init, headers })
+  request.runtime = event.req.runtime
+  request.waitUntil = event.req.waitUntil
+  request.ip = event.req.ip
+  return _useNitroApp().fetch(request)
+}
+export function fetchRawWithEvent(event, request, init) {
+  return fetchRaw(event, request, init)
+}
 export function fetchWithEvent(event, request, options) {
   const localFetch = createFetch({
-    fetch: (input, init) => fetchRawWithEvent(event, input, init),
+    fetch: (input, init) => fetchRaw(event, input, init),
   })
   return localFetch(request, options)
 }
@@ -110,6 +130,7 @@ export { defineCachedFunction, defineCachedHandler as defineCachedEventHandler }
 export { useStorage } from 'nitro/storage'
 export { defineTask, runTask } from 'nitro/task'
 export function fetchWithEvent<T>(event: import('nitro/h3').H3Event, request: import('ofetch').FetchRequest, options?: import('ofetch').FetchOptions): Promise<T>
+export function fetchRawWithEvent(event: import('nitro/h3').H3Event, request: RequestInfo | URL, init?: RequestInit): Promise<Response>
 `
 
 function indent(value: string, spaces: number): string {

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -54,6 +54,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useEvent')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.$fetch(request, options)')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.fetch(request, init)')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBeUndefined()
     expect(resolveModuleMock).not.toHaveBeenCalled()
@@ -64,6 +65,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('declare module \'#nuxtseo/nitro\'')
     await expect(template.getContents()).resolves.toContain('from \'nitropack/runtime\'')
     await expect(template.getContents()).resolves.toContain('export function fetchWithEvent<T>')
+    await expect(template.getContents()).resolves.toContain('export function fetchRawWithEvent(')
   })
 
   it('registers Nitro 3 runtime entrypoints and type targets', async () => {
@@ -84,7 +86,8 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).not.toContain('getRouteRules')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('useRequest as useEvent } from \'nitro/context\'')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedHandler as defineCachedEventHandler')
-    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('fetchRawWithEvent(event, input, init)')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('return _useNitroApp().fetch(request)')
+    expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('export function fetchRawWithEvent(event, request, init)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'#nuxtseo/ofetch\'')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
@@ -97,6 +100,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('defineCachedHandler as defineCachedEventHandler')
     await expect(template.getContents()).resolves.toContain('export * from \'nitro/h3\'')
     await expect(template.getContents()).resolves.toContain('export function fetchWithEvent<T>')
+    await expect(template.getContents()).resolves.toContain('export function fetchRawWithEvent(')
   })
 
   it('registers shared templates once when several modules call setup', () => {


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Adds a raw response fetch helper to the shared Nitro compatibility layer. Nitro 2 delegates to the event fetch API. Nitro 3 dispatches relative requests through the Nitro app so global middleware and async context remain available.

The parsed fetch helper now builds on the raw helper. Unit coverage verifies both Nitro virtual modules.