### PR TITLE
fix(shared): emit resolvable H3 server types

### DIFF
--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -1,5 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
-import { addTypeTemplate, directoryToURL, getNuxtVersion, resolveModule, useNuxt } from '@nuxt/kit'
+import { addTypeTemplate, directoryToURL, getNuxtVersion, resolveModule, useLogger, useNuxt } from '@nuxt/kit'
 
 export type NitroRuntimeCompatibility
   = | {
@@ -160,31 +160,47 @@ ${indent(h3Runtime.trim(), 2)}
 `
 }
 
-function resolveRuntimeModule(nuxt: Nuxt, id: string): string {
+type RuntimeModuleResolution
+  = | { _tag: 'resolved', path: string }
+    | { _tag: 'unresolved', cause: unknown }
+
+function resolveRuntimeModule(nuxt: Nuxt, id: string): RuntimeModuleResolution {
   try {
     // Resolve from the project first: `nitro/h3` only exists in the consuming app's
     // dependency tree, and under a strict pnpm layout `h3` is not guaranteed to be
     // reachable from this package either.
-    return resolveModule(id, {
-      url: [...(nuxt.options.modulesDir ?? []).map(directoryToURL), new URL(import.meta.url)],
-    })
+    return {
+      _tag: 'resolved',
+      path: resolveModule(id, {
+        url: [...nuxt.options.modulesDir.map(directoryToURL), new URL(import.meta.url)],
+      }),
+    }
   }
-  catch {
-    // Fall back to the bare specifier: the bundler still resolves it, we only lose the
-    // absolute target in the generated `tsconfig.server.json` `paths` entry.
-    return id
+  catch (cause) {
+    return { _tag: 'unresolved', cause }
   }
 }
 
-function applyNitroRuntimeCompatibility(nuxt: Nuxt, compatibility: NitroRuntimeCompatibility): void {
+function applyNitroRuntimeCompatibility(
+  nuxt: Nuxt,
+  compatibility: NitroRuntimeCompatibility,
+  reportResolutionFailure = false,
+): void {
   const nuxtOptions = nuxt.options as Nuxt['options'] & { nitro?: NuxtNitroCompatibilityOptions }
   const nitroOptions = nuxtOptions.nitro ||= {}
   nitroOptions.alias ||= {}
   nitroOptions.virtual ||= {}
-  nitroOptions.alias[H3_RUNTIME_MODULE] = resolveRuntimeModule(
-    nuxt,
-    compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3',
-  )
+  const h3RuntimeModule = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
+  const h3Resolution = resolveRuntimeModule(nuxt, h3RuntimeModule)
+  nitroOptions.alias[H3_RUNTIME_MODULE] = h3Resolution._tag === 'resolved'
+    ? h3Resolution.path
+    : h3RuntimeModule
+  if (reportResolutionFailure && h3Resolution._tag === 'unresolved') {
+    useLogger('nuxtseo-shared').warn(
+      `Could not resolve Nitro runtime module '${h3RuntimeModule}'. Generated server types may be incomplete.`,
+      h3Resolution.cause,
+    )
+  }
   if (compatibility._tag === 'nitro-v3')
     nitroOptions.alias[OFETCH_RUNTIME_MODULE] = resolveModule('ofetch', { url: new URL(import.meta.url) })
   nitroOptions.virtual[NITRO_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime
@@ -225,7 +241,7 @@ export function setupNitroRuntimeCompatibility(nuxt: Nuxt = useNuxt()): NitroRun
   const nuxtWithRuntimeMarker = nuxt as Nuxt & { [runtimeSetupMarker]?: true }
   if (!nuxtWithRuntimeMarker[runtimeSetupMarker]) {
     nuxtWithRuntimeMarker[runtimeSetupMarker] = true
-    nuxt.hooks.hookOnce('modules:done', () => applyNitroRuntimeCompatibility(nuxt, compatibility))
+    nuxt.hooks.hookOnce('modules:done', () => applyNitroRuntimeCompatibility(nuxt, compatibility, true))
   }
 
   const nuxtWithTypeMarker = nuxt as Nuxt & { [typeSetupMarker]?: true }

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -1,5 +1,5 @@
 import type { Nuxt } from '@nuxt/schema'
-import { addTypeTemplate, getNuxtVersion, resolveModule, useNuxt } from '@nuxt/kit'
+import { addTypeTemplate, directoryToURL, getNuxtVersion, resolveModule, useNuxt } from '@nuxt/kit'
 
 export type NitroRuntimeCompatibility
   = | {
@@ -160,12 +160,31 @@ ${indent(h3Runtime.trim(), 2)}
 `
 }
 
+function resolveRuntimeModule(nuxt: Nuxt, id: string): string {
+  try {
+    // Resolve from the project first: `nitro/h3` only exists in the consuming app's
+    // dependency tree, and under a strict pnpm layout `h3` is not guaranteed to be
+    // reachable from this package either.
+    return resolveModule(id, {
+      url: [...(nuxt.options.modulesDir ?? []).map(directoryToURL), new URL(import.meta.url)],
+    })
+  }
+  catch {
+    // Fall back to the bare specifier: the bundler still resolves it, we only lose the
+    // absolute target in the generated `tsconfig.server.json` `paths` entry.
+    return id
+  }
+}
+
 function applyNitroRuntimeCompatibility(nuxt: Nuxt, compatibility: NitroRuntimeCompatibility): void {
   const nuxtOptions = nuxt.options as Nuxt['options'] & { nitro?: NuxtNitroCompatibilityOptions }
   const nitroOptions = nuxtOptions.nitro ||= {}
   nitroOptions.alias ||= {}
   nitroOptions.virtual ||= {}
-  nitroOptions.alias[H3_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
+  nitroOptions.alias[H3_RUNTIME_MODULE] = resolveRuntimeModule(
+    nuxt,
+    compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3',
+  )
   if (compatibility._tag === 'nitro-v3')
     nitroOptions.alias[OFETCH_RUNTIME_MODULE] = resolveModule('ofetch', { url: new URL(import.meta.url) })
   nitroOptions.virtual[NITRO_RUNTIME_MODULE] = compatibility._tag === 'nitro-v3' ? nitroV3Runtime : nitroV2Runtime

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -35,6 +35,13 @@ const runtimeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:reque
 
 interface NuxtNitroCompatibilityOptions {
   alias?: Record<string, string>
+  typescript?: {
+    tsConfig?: {
+      compilerOptions?: {
+        paths?: Record<string, string[]>
+      }
+    }
+  }
   virtual?: Record<string, string>
 }
 
@@ -191,11 +198,16 @@ function applyNitroRuntimeCompatibility(
   nitroOptions.alias ||= {}
   nitroOptions.virtual ||= {}
   const h3RuntimeModule = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
+  nitroOptions.alias[H3_RUNTIME_MODULE] = h3RuntimeModule
   const h3Resolution = resolveRuntimeModule(nuxt, h3RuntimeModule)
-  nitroOptions.alias[H3_RUNTIME_MODULE] = h3Resolution._tag === 'resolved'
-    ? h3Resolution.path
-    : h3RuntimeModule
-  if (reportResolutionFailure && h3Resolution._tag === 'unresolved') {
+  if (h3Resolution._tag === 'resolved') {
+    nitroOptions.typescript ||= {}
+    nitroOptions.typescript.tsConfig ||= {}
+    nitroOptions.typescript.tsConfig.compilerOptions ||= {}
+    nitroOptions.typescript.tsConfig.compilerOptions.paths ||= {}
+    nitroOptions.typescript.tsConfig.compilerOptions.paths[H3_RUNTIME_MODULE] = [h3Resolution.path]
+  }
+  else if (reportResolutionFailure) {
     useLogger('nuxtseo-shared').warn(
       `Could not resolve Nitro runtime module '${h3RuntimeModule}'. Generated server types may be incomplete.`,
       h3Resolution.cause,

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -23,9 +23,16 @@ function createNuxt(): Nuxt {
       hookOnce: hookOnceMock,
     },
     options: {
+      modulesDir: ['/project/node_modules'],
       nitro: {},
     },
-  } as Nuxt
+  } as unknown as Nuxt
+}
+
+function resolveSourcesFor(id: string): URL[] {
+  const call = resolveModuleMock.mock.calls.find(([calledId]) => calledId === id)
+  expect(call, `resolveModule was not called for '${id}'`).toBeDefined()
+  return call![1].url as URL[]
 }
 
 describe('setupNitroRuntimeCompatibility', () => {
@@ -34,7 +41,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     getNuxtVersionMock.mockReset()
     hookOnceMock.mockReset()
     resolveModuleMock.mockReset()
-    resolveModuleMock.mockReturnValue('/resolved/ofetch.mjs')
+    resolveModuleMock.mockImplementation((id: string) => `/resolved/${id.replace(/\//g, '-')}.mjs`)
   })
 
   it('registers Nitro 2 runtime virtual module and H3 alias', async () => {
@@ -55,9 +62,12 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.$fetch(request, options)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.fetch(request, init)')
-    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/h3.mjs')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBeUndefined()
-    expect(resolveModuleMock).not.toHaveBeenCalled()
+    // resolution must start from the consuming project, not from this package
+    const h3Sources = resolveSourcesFor('h3')
+    expect(h3Sources[0]!.href).toContain('/project/node_modules')
+    expect(h3Sources.at(-1)!.href).toContain('nitro-compatibility')
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
@@ -89,8 +99,10 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('return _useNitroApp().fetch(request)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('export function fetchRawWithEvent(event, request, init)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'#nuxtseo/ofetch\'')
-    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/nitro-h3.mjs')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
+    // `nitro/h3` only exists in the consuming project's dependency tree
+    expect(resolveSourcesFor('nitro/h3')[0]!.href).toContain('/project/node_modules')
     expect(resolveModuleMock).toHaveBeenCalledWith('ofetch', { url: expect.any(URL) })
     expect(addTypeTemplateMock).toHaveBeenCalledWith(expect.any(Object), { nitro: true, nuxt: true })
 
@@ -101,6 +113,32 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('export * from \'nitro/h3\'')
     await expect(template.getContents()).resolves.toContain('export function fetchWithEvent<T>')
     await expect(template.getContents()).resolves.toContain('export function fetchRawWithEvent(')
+  })
+
+  it('resolves the H3 alias when the Nuxt instance exposes no module directories', () => {
+    getNuxtVersionMock.mockReturnValue('4.5.1')
+    const nuxt = createNuxt()
+    // @ts-expect-error - an older or partially built Nuxt instance may not carry it
+    nuxt.options.modulesDir = undefined
+
+    expect(() => setupNitroRuntimeCompatibility(nuxt)).not.toThrow()
+
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/h3.mjs')
+  })
+
+  it('falls back to the bare specifier when the H3 runtime module cannot be resolved', () => {
+    getNuxtVersionMock.mockReturnValue('5.0.0-29762522.15e6ea5a')
+    resolveModuleMock.mockImplementation((id: string) => {
+      if (id === 'nitro/h3')
+        throw new Error('Cannot find module \'nitro/h3\'')
+      return `/resolved/${id}.mjs`
+    })
+    const nuxt = createNuxt()
+
+    setupNitroRuntimeCompatibility(nuxt)
+
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
   })
 
   it('registers shared templates once when several modules call setup', () => {

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -3,11 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { renderNitroTypeAugmentations, setupNitroRuntimeCompatibility } from '../../src/kit'
 
-const { addTypeTemplateMock, getNuxtVersionMock, hookOnceMock, resolveModuleMock } = vi.hoisted(() => ({
+const { addTypeTemplateMock, getNuxtVersionMock, hookOnceMock, resolveModuleMock, warnMock } = vi.hoisted(() => ({
   addTypeTemplateMock: vi.fn(),
   getNuxtVersionMock: vi.fn(),
   hookOnceMock: vi.fn(),
   resolveModuleMock: vi.fn(),
+  warnMock: vi.fn(),
 }))
 
 vi.mock('@nuxt/kit', async importOriginal => ({
@@ -15,6 +16,7 @@ vi.mock('@nuxt/kit', async importOriginal => ({
   addTypeTemplate: addTypeTemplateMock,
   getNuxtVersion: getNuxtVersionMock,
   resolveModule: resolveModuleMock,
+  useLogger: () => ({ warn: warnMock }),
 }))
 
 function createNuxt(): Nuxt {
@@ -41,6 +43,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     getNuxtVersionMock.mockReset()
     hookOnceMock.mockReset()
     resolveModuleMock.mockReset()
+    warnMock.mockReset()
     resolveModuleMock.mockImplementation((id: string) => `/resolved/${id.replace(/\//g, '-')}.mjs`)
   })
 
@@ -115,18 +118,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     await expect(template.getContents()).resolves.toContain('export function fetchRawWithEvent(')
   })
 
-  it('resolves the H3 alias when the Nuxt instance exposes no module directories', () => {
-    getNuxtVersionMock.mockReturnValue('4.5.1')
-    const nuxt = createNuxt()
-    // @ts-expect-error - an older or partially built Nuxt instance may not carry it
-    nuxt.options.modulesDir = undefined
-
-    expect(() => setupNitroRuntimeCompatibility(nuxt)).not.toThrow()
-
-    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/h3.mjs')
-  })
-
-  it('falls back to the bare specifier when the H3 runtime module cannot be resolved', () => {
+  it('reports a degraded H3 alias when final resolution fails', () => {
     getNuxtVersionMock.mockReturnValue('5.0.0-29762522.15e6ea5a')
     resolveModuleMock.mockImplementation((id: string) => {
       if (id === 'nitro/h3')
@@ -139,6 +131,16 @@ describe('setupNitroRuntimeCompatibility', () => {
 
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
+    expect(warnMock).not.toHaveBeenCalled()
+
+    const applyCompatibility = hookOnceMock.mock.calls[0]![1]
+    applyCompatibility()
+
+    expect(warnMock).toHaveBeenCalledOnce()
+    expect(warnMock).toHaveBeenCalledWith(
+      'Could not resolve Nitro runtime module \'nitro/h3\'. Generated server types may be incomplete.',
+      expect.any(Error),
+    )
   })
 
   it('registers shared templates once when several modules call setup', () => {

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -65,7 +65,10 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('defineCachedEventHandler')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.$fetch(request, options)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('event.fetch(request, init)')
-    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/h3.mjs')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('h3')
+    expect(nuxt.options.nitro.typescript?.tsConfig?.compilerOptions?.paths?.['#nuxtseo/h3']).toEqual([
+      '/resolved/h3.mjs',
+    ])
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBeUndefined()
     // resolution must start from the consuming project, not from this package
     const h3Sources = resolveSourcesFor('h3')
@@ -102,7 +105,10 @@ describe('setupNitroRuntimeCompatibility', () => {
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('return _useNitroApp().fetch(request)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('export function fetchRawWithEvent(event, request, init)')
     expect(nuxt.options.nitro.virtual?.['#nuxtseo/nitro']).toContain('from \'#nuxtseo/ofetch\'')
-    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('/resolved/nitro-h3.mjs')
+    expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
+    expect(nuxt.options.nitro.typescript?.tsConfig?.compilerOptions?.paths?.['#nuxtseo/h3']).toEqual([
+      '/resolved/nitro-h3.mjs',
+    ])
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
     // `nitro/h3` only exists in the consuming project's dependency tree
     expect(resolveSourcesFor('nitro/h3')[0]!.href).toContain('/project/node_modules')
@@ -130,6 +136,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     setupNitroRuntimeCompatibility(nuxt)
 
     expect(nuxt.options.nitro.alias?.['#nuxtseo/h3']).toBe('nitro/h3')
+    expect(nuxt.options.nitro.typescript?.tsConfig?.compilerOptions?.paths?.['#nuxtseo/h3']).toBeUndefined()
     expect(nuxt.options.nitro.alias?.['#nuxtseo/ofetch']).toBe('/resolved/ofetch.mjs')
     expect(warnMock).not.toHaveBeenCalled()
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #607

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Nuxt copied the bare `#nuxtseo/h3` runtime target into `.nuxt/tsconfig.server.json` as a build directory path that did not exist. Shipped declarations could then lose their H3 types.

`applyNitroRuntimeCompatibility` now keeps the runtime alias as `h3` or `nitro/h3`. It resolves the type target from `nuxt.options.modulesDir` and writes the absolute path only to `nitro.typescript.tsConfig.compilerOptions.paths`. Nuxt normalizes that target when it generates `.nuxt/tsconfig.server.json`.

`modulesDir` includes the project dependency directory and configured workspace or layer directories, matching Nuxt's own Nitro resolution inputs. No root toggle is needed. Resolution retries after module setup and warns if the final type target cannot be found.

### 🔍 How it was verified

- `pnpm --filter nuxtseo-shared test:run`: 8 files and 113 tests, including Nuxt 5 prepare, typecheck, and production build coverage
- `pnpm --filter @nuxtjs/seo test:nitro-parity`: Nitro 2 and Nitro 3 generated types and production output match
- `pnpm lint`
- `pnpm typecheck`
- `pnpm dev:prepare`
- `pnpm build`
