### PR TITLE
feat(shared): add runtime-safe i18n route resolution

### DIFF
--- a/packages/nuxt-seo/test/integration/standalone-modules-prerender.test.ts
+++ b/packages/nuxt-seo/test/integration/standalone-modules-prerender.test.ts
@@ -59,27 +59,25 @@ describe('standalone modules (prerendered)', () => {
     // Same header as llms.txt
     expect(txt).toContain('# @nuxtjs/seo')
     expect(txt).toContain('Canonical Origin: https://local.nuxtseo.com')
-    expect(txt).toContain('## Pages')
+    expect(txt).toContain('## LLM Resources')
 
-    // Full per-page sections with source, description and the page's markdown
-    // body. Streaming order depends on prerender completion, so assert each
-    // block independently rather than the whole document.
+    // Full per-page records with source, description and the page's markdown
+    // body. Prerender completion controls record order, so assert each block
+    // independently rather than the whole document.
     expect(txt).toContain([
-      '### @nuxtjs&#x2F;seo',
+      '- **Page:** @nuxtjs&#x2F;seo',
+      '- **Source:** https://local.nuxtseo.com/',
+      '- **Description:** Fully equipped Technical SEO for busy Nuxters.',
       '',
-      'Source: https://local.nuxtseo.com/',
-      'Description: Fully equipped Technical SEO for busy Nuxters.',
-      '',
-      'h1. home',
+      '# home',
     ].join('\n'))
 
     expect(txt).toContain([
-      '### About | @nuxtjs&#x2F;seo',
+      '- **Page:** About | @nuxtjs&#x2F;seo',
+      '- **Source:** https://local.nuxtseo.com/about',
+      '- **Description:** Fully equipped Technical SEO for busy Nuxters.',
       '',
-      'Source: https://local.nuxtseo.com/about',
-      'Description: Fully equipped Technical SEO for busy Nuxters.',
-      '',
-      'h1. about',
+      '# about',
     ].join('\n'))
   })
 

--- a/packages/shared/build.config.ts
+++ b/packages/shared/build.config.ts
@@ -8,6 +8,7 @@ export default defineBuildConfig({
     { input: 'src/kit', name: 'kit' },
     { input: 'src/devtools', name: 'devtools' },
     { input: 'src/i18n', name: 'i18n' },
+    { input: 'src/i18n-runtime', name: 'i18n-runtime' },
     { input: 'src/pro', name: 'pro' },
     { input: 'src/utils', name: 'utils' },
     { input: 'src/const', name: 'const' },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/i18n.d.mts",
       "default": "./dist/i18n.mjs"
     },
+    "./i18n-runtime": {
+      "types": "./dist/i18n-runtime.d.mts",
+      "default": "./dist/i18n-runtime.mjs"
+    },
     "./pro": {
       "types": "./dist/pro.d.mts",
       "default": "./dist/pro.mjs"

--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -18,16 +18,24 @@
  */
 export type LocalePages = Record<string, Record<string, string | false> | undefined>
 
+export interface RuntimeLocale {
+  code: string
+  hreflang: string
+  name?: string
+  nativeName?: string
+  language?: string
+  domain?: string
+  domains?: string[]
+  defaultForDomains?: string[]
+}
+
 /** Runtime-safe subset of `AutoI18nConfig` used for route locale resolution. */
 export interface RuntimeI18nConfig {
   defaultLocale: string
   strategy: 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
-  locales: Array<{
-    code: string
-    hreflang: string
-    name?: string
-    nativeName?: string
-  }>
+  locales: RuntimeLocale[]
+  differentDomains?: boolean
+  multiDomainLocales?: boolean
   /** Translated route paths, when i18n is configured with custom routes. */
   pages?: LocalePages
 }
@@ -36,6 +44,7 @@ export interface LocaleAlternate {
   code: string
   hreflang: string
   path: string
+  domain?: string
 }
 
 export interface RouteLocaleInfo {
@@ -45,40 +54,96 @@ export interface RouteLocaleInfo {
   basePath: string
 }
 
+export interface RuntimeRouteContext {
+  /** Request host, used to resolve locales under domain-based strategies. */
+  host?: string
+}
+
+function normalizeHost(value: string): string {
+  return value.trim().toLowerCase().replace(/^[a-z][a-z\d+.-]*:\/\//, '').split('/')[0]!
+}
+
+function localeDomains(locale: RuntimeLocale): string[] {
+  return locale.domains?.length ? locale.domains : locale.domain ? [locale.domain] : []
+}
+
+function resolveLocaleFromHost(host: string | undefined, i18n: RuntimeI18nConfig): RuntimeLocale | undefined {
+  if (!host)
+    return undefined
+  const normalizedHost = normalizeHost(host)
+  const domainDefault = i18n.locales.find(locale =>
+    locale.defaultForDomains?.some(domain => normalizeHost(domain) === normalizedHost),
+  )
+  if (domainDefault)
+    return domainDefault
+  const matches = i18n.locales.filter(locale =>
+    localeDomains(locale).some(domain => normalizeHost(domain) === normalizedHost),
+  )
+  return matches.length === 1 ? matches[0] : matches.find(locale => locale.code === i18n.defaultLocale)
+}
+
+function resolveLocaleDomain(locale: RuntimeLocale): string | undefined {
+  return locale.defaultForDomains?.[0] || locale.domain || locale.domains?.[0]
+}
+
+function splitRouteSuffix(route: string): { pathname: string, suffix: string } {
+  const suffixIndex = route.search(/[?#]/)
+  const rawPathname = suffixIndex === -1 ? route : route.slice(0, suffixIndex)
+  return {
+    pathname: rawPathname ? (rawPathname.startsWith('/') ? rawPathname : `/${rawPathname}`) : '/',
+    suffix: suffixIndex === -1 ? '' : route.slice(suffixIndex),
+  }
+}
+
 /**
  * Resolve which locale a route belongs to and the locale-stripped base path.
  */
-export function resolveLocaleFromRoute(route: string, i18n: RuntimeI18nConfig): RouteLocaleInfo {
-  if (i18n.strategy === 'no_prefix')
-    return { locale: i18n.defaultLocale, basePath: route }
+export function resolveLocaleFromRoute(route: string, i18n: RuntimeI18nConfig, context: RuntimeRouteContext = {}): RouteLocaleInfo {
+  const { pathname, suffix } = splitRouteSuffix(route)
+  if (i18n.strategy !== 'no_prefix') {
+    const segments = pathname.split('/').filter(Boolean)
+    const first = segments[0]
+    const matched = first ? i18n.locales.find(l => l.code === first) : undefined
 
-  const segments = route.split('/').filter(Boolean)
-  const first = segments[0]
-  const matched = first ? i18n.locales.find(l => l.code === first) : undefined
-
-  if (matched) {
-    const rest = segments.slice(1).join('/')
-    return { locale: matched.code, basePath: rest ? `/${rest}` : '/' }
+    if (matched) {
+      const rest = segments.slice(1).join('/')
+      return { locale: matched.code, basePath: `${rest ? `/${rest}` : '/'}${suffix}` }
+    }
   }
 
-  return { locale: i18n.defaultLocale, basePath: route }
+  const domainLocale = resolveLocaleFromHost(context.host, i18n)
+  return { locale: domainLocale?.code || i18n.defaultLocale, basePath: `${pathname}${suffix}` }
 }
 
 /**
  * Build the URL path for a base path under a given locale, honoring the i18n strategy.
  */
-export function localePath(basePath: string, locale: string, i18n: RuntimeI18nConfig): string {
+export function localePath(
+  basePath: string,
+  locale: string,
+  i18n: RuntimeI18nConfig,
+  context: RuntimeRouteContext = {},
+): string {
+  const { pathname, suffix } = splitRouteSuffix(basePath)
   if (i18n.strategy === 'no_prefix')
-    return basePath
+    return `${pathname}${suffix}`
 
   const isDefault = locale === i18n.defaultLocale
-  if (i18n.strategy === 'prefix_except_default' && isDefault)
-    return basePath
+  const localeConfig = i18n.locales.find(item => item.code === locale)
+  const normalizedHost = context.host ? normalizeHost(context.host) : undefined
+  const matchesDomainDefault = !!normalizedHost
+    && !!localeConfig?.defaultForDomains?.some(domain => normalizeHost(domain) === normalizedHost)
+  const isDomainDefault = i18n.differentDomains
+    || matchesDomainDefault
+  if (i18n.strategy === 'prefix_except_default' && (isDefault || isDomainDefault))
+    return `${pathname}${suffix}`
+  if (i18n.strategy === 'prefix_and_default' && isDomainDefault)
+    return `${pathname}${suffix}`
 
   // prefix, prefix_and_default, prefix_except_default (non-default)
-  if (basePath === '/' || basePath === '')
-    return `/${locale}`
-  return `/${locale}${basePath}`
+  if (pathname === '/')
+    return `/${locale}${suffix}`
+  return `/${locale}${pathname}${suffix}`
 }
 
 function toSegments(path: string): string[] {
@@ -91,30 +156,58 @@ interface PageParam {
   optional: boolean
 }
 
-/**
- * Read a dynamic segment: `[slug]`, `[[slug]]`, `[...slug]`, `[[...slug]]` and
- * the router equivalents `:slug`, `:slug?`, `:slug(.*)`.
- */
-function readParam(segment: string): PageParam | null {
-  if (segment.startsWith('[') && segment.endsWith(']')) {
-    let name = segment.slice(1, -1)
-    let optional = false
-    if (name.startsWith('[') && name.endsWith(']')) {
-      name = name.slice(1, -1)
-      optional = true
+interface StaticPageToken {
+  _tag: 'static'
+  value: string
+}
+
+interface ParamPageToken {
+  _tag: 'param'
+  param: PageParam
+}
+
+type PageToken = StaticPageToken | ParamPageToken
+
+// Nuxt bracket params plus the Vue Router forms i18n emits. Parsing tokens
+// instead of whole segments also covers paths such as `/archive/[year]-[slug]`.
+const PAGE_PARAM_PATTERN = /\[\[(\.\.\.)?([^[\]]+)\]\]|\[(\.\.\.)?([^[\]]+)\]|:(\w+)(?:\((\.\*)\))?([?*+]?)/g
+
+function parsePageSegment(segment: string): PageToken[] {
+  const tokens: PageToken[] = []
+  let offset = 0
+
+  for (const match of segment.matchAll(PAGE_PARAM_PATTERN)) {
+    const index = match.index
+    if (index > offset)
+      tokens.push({ _tag: 'static', value: segment.slice(offset, index) })
+
+    if (match[2]) {
+      tokens.push({ _tag: 'param', param: { name: match[2], catchAll: !!match[1], optional: true } })
     }
-    const catchAll = name.startsWith('...')
-    if (catchAll)
-      name = name.slice(3)
-    // Anything still carrying a bracket isn't a segment we understand.
-    if (!name || name.includes('[') || name.includes(']'))
-      return null
-    return { name, catchAll, optional }
+    else if (match[4]) {
+      tokens.push({ _tag: 'param', param: { name: match[4], catchAll: !!match[3], optional: false } })
+    }
+    else {
+      const modifier = match[7]
+      tokens.push({
+        _tag: 'param',
+        param: {
+          name: match[5]!,
+          catchAll: !!match[6] || modifier === '*' || modifier === '+',
+          optional: modifier === '?' || modifier === '*',
+        },
+      })
+    }
+    offset = index + match[0].length
   }
-  const colon = /^:([^(?*+]+)([?*+])?(\(\.\*\))?$/.exec(segment)
-  if (colon)
-    return { name: colon[1]!, catchAll: !!colon[3] || colon[2] === '*', optional: colon[2] === '?' || colon[2] === '*' }
-  return null
+
+  if (offset < segment.length)
+    tokens.push({ _tag: 'static', value: segment.slice(offset) })
+  return tokens.length ? tokens : [{ _tag: 'static', value: segment }]
+}
+
+function wholeSegmentParam(tokens: PageToken[]): PageParam | null {
+  return tokens.length === 1 && tokens[0]?._tag === 'param' ? tokens[0].param : null
 }
 
 /**
@@ -125,23 +218,57 @@ function readParam(segment: string): PageParam | null {
  */
 function segmentRanks(pattern: string): number[] {
   return toSegments(pattern).map((segment) => {
-    const param = readParam(segment)
-    if (!param)
-      return 2
-    return param.catchAll ? 0 : 1
+    const tokens = parsePageSegment(segment)
+    const params = tokens.filter((token): token is ParamPageToken => token._tag === 'param')
+    if (!params.length)
+      return 6
+    const hasStatic = tokens.some(token => token._tag === 'static')
+    if (hasStatic)
+      return params.some(token => token.param.optional) ? 3 : 4
+    const param = params[0]!.param
+    if (param.catchAll)
+      return param.optional ? -1 : 0
+    return param.optional ? 1 : 2
   })
 }
 
 /** Negative when `a` is more specific than `b`, for use as a sort comparator. */
 function compareSpecificity(a: number[], b: number[]): number {
-  const length = Math.max(a.length, b.length)
+  const length = Math.min(a.length, b.length)
   for (let i = 0; i < length; i++) {
-    // A pattern that ran out of segments is the less specific of the two.
-    const diff = (b[i] ?? -1) - (a[i] ?? -1)
+    const diff = b[i]! - a[i]!
     if (diff !== 0)
       return diff
   }
-  return 0
+  // When both patterns match, extra segments are optional. The exact, shorter
+  // route wins over a sibling such as `/blog/[[slug]]`.
+  return a.length - b.length
+}
+
+function matchSegmentTokens(tokens: PageToken[], path: string): Record<string, string> | null {
+  function visit(index: number, offset: number, params: Record<string, string>): Record<string, string> | null {
+    if (index === tokens.length)
+      return offset === path.length ? params : null
+
+    const token = tokens[index]!
+    if (token._tag === 'static') {
+      return path.startsWith(token.value, offset)
+        ? visit(index + 1, offset + token.value.length, params)
+        : null
+    }
+
+    const minimumEnd = token.param.optional ? offset : offset + 1
+    for (let end = minimumEnd; end <= path.length; end++) {
+      const value = path.slice(offset, end)
+      const nextParams = value ? { ...params, [token.param.name]: value } : params
+      const matched = visit(index + 1, end, nextParams)
+      if (matched)
+        return matched
+    }
+    return null
+  }
+
+  return visit(0, 0, {})
 }
 
 /**
@@ -151,64 +278,78 @@ function compareSpecificity(a: number[], b: number[]): number {
 function matchPagePattern(pattern: string, path: string): Record<string, string> | null {
   const patternSegments = toSegments(pattern)
   const pathSegments = toSegments(path)
-  const params: Record<string, string> = {}
 
-  for (let i = 0; i < patternSegments.length; i++) {
-    const param = readParam(patternSegments[i]!)
+  function visit(patternIndex: number, pathIndex: number, params: Record<string, string>): Record<string, string> | null {
+    if (patternIndex === patternSegments.length)
+      return pathIndex === pathSegments.length ? params : null
+
+    const tokens = parsePageSegment(patternSegments[patternIndex]!)
+    const param = wholeSegmentParam(tokens)
     if (param?.catchAll) {
-      const rest = pathSegments.slice(i)
-      if (!rest.length)
-        return param.optional ? params : null
-      params[param.name] = rest.join('/')
-      return params
-    }
-    const segment = pathSegments[i]
-    if (segment === undefined) {
-      // The path stopped early: fine only if every segment left is optional.
-      return patternSegments.slice(i).every(s => readParam(s)?.optional) ? params : null
-    }
-    if (param)
-      params[param.name] = segment
-    else if (patternSegments[i] !== segment)
+      const minimumEnd = param.optional ? pathIndex : pathIndex + 1
+      for (let end = pathSegments.length; end >= minimumEnd; end--) {
+        const value = pathSegments.slice(pathIndex, end).join('/')
+        const nextParams = value ? { ...params, [param.name]: value } : params
+        const matched = visit(patternIndex + 1, end, nextParams)
+        if (matched)
+          return matched
+      }
       return null
+    }
+
+    const segment = pathSegments[pathIndex]
+    if (segment !== undefined) {
+      const segmentParams = matchSegmentTokens(tokens, segment)
+      if (segmentParams) {
+        const matched = visit(patternIndex + 1, pathIndex + 1, { ...params, ...segmentParams })
+        if (matched)
+          return matched
+      }
+    }
+
+    return param?.optional ? visit(patternIndex + 1, pathIndex, params) : null
   }
 
-  return pathSegments.length === patternSegments.length ? params : null
+  return visit(0, 0, {})
 }
 
 /** Render a pattern with captured params. Null when a param has no value. */
 function fillPagePattern(pattern: string, params: Record<string, string>): string | null {
   const filled: string[] = []
   for (const segment of toSegments(pattern)) {
-    const param = readParam(segment)
-    if (!param) {
-      filled.push(segment)
-      continue
-    }
-    const value = params[param.name]
-    if (value === undefined) {
-      if (param.optional)
+    const tokens = parsePageSegment(segment)
+    let value = ''
+    for (const token of tokens) {
+      if (token._tag === 'static') {
+        value += token.value
         continue
-      return null
+      }
+      const paramValue = params[token.param.name]
+      if (paramValue === undefined) {
+        if (token.param.optional)
+          continue
+        return null
+      }
+      value += paramValue
     }
-    filled.push(value)
+    if (value)
+      filled.push(value)
   }
   return filled.length ? `/${filled.join('/')}` : '/'
 }
 
 /**
- * Build the alternates for one matched entry, or null when a locale the entry
- * does name can't be rendered from the captured params.
+ * Build the known alternates for one matched entry. Unknown paths are omitted
+ * instead of fabricating URLs from another locale's translated slug.
  */
 function alternatesForEntry(
   localePaths: Record<string, string | false>,
   params: Record<string, string>,
-  basePath: string,
   i18n: RuntimeI18nConfig,
+  context: RuntimeRouteContext,
 ): LocaleAlternate[] | null {
-  // Locales the entry doesn't name keep the untranslated route path, which the
-  // table doesn't record. The default locale's pattern is the closest thing to
-  // it we have; without one, fall back to the path that was requested.
+  // Locales the entry doesn't name use the default pattern when available.
+  // Without that pattern the original route is unknowable from i18n pages.
   const untranslated = localePaths[i18n.defaultLocale]
   const alternates: LocaleAlternate[] = []
 
@@ -217,17 +358,21 @@ function alternatesForEntry(
     // Disabled for this locale: no page, so no alternate.
     if (localePaths[l.code] === false)
       continue
-    const path = typeof pattern === 'string' ? fillPagePattern(pattern, params) : basePath
+    if (typeof pattern !== 'string')
+      continue
+    const path = fillPagePattern(pattern, params)
     if (path === null)
-      return null
+      continue
+    const domain = resolveLocaleDomain(l)
     alternates.push({
       code: l.code,
       hreflang: l.hreflang || l.code,
-      path: localePath(path, l.code, i18n),
+      path: localePath(path, l.code, i18n, { host: domain || context.host }),
+      ...(domain ? { domain } : {}),
     })
   }
 
-  return alternates
+  return alternates.length ? alternates : null
 }
 
 /**
@@ -236,11 +381,15 @@ function alternatesForEntry(
  * Returns null when the pages map can't answer for this route, in which case
  * the caller falls back to locale-prefix arithmetic.
  */
-function alternatesFromPages(basePath: string, locale: string, i18n: RuntimeI18nConfig): LocaleAlternate[] | null {
-  // no_prefix gives every locale the same single URL, so there is nothing to
-  // translate between.
+function alternatesFromPages(
+  basePath: string,
+  locale: string,
+  i18n: RuntimeI18nConfig,
+  context: RuntimeRouteContext,
+): LocaleAlternate[] | null {
   const pages = i18n.pages
-  if (!pages || i18n.strategy === 'no_prefix')
+  const hasDomainLocales = i18n.differentDomains || i18n.multiDomainLocales
+  if (!pages || (i18n.strategy === 'no_prefix' && !hasDomainLocales))
     return null
 
   const matches: Array<{ ranks: number[], localePaths: Record<string, string | false>, params: Record<string, string> }> = []
@@ -256,7 +405,7 @@ function alternatesFromPages(basePath: string, locale: string, i18n: RuntimeI18n
   matches.sort((a, b) => compareSpecificity(a.ranks, b.ranks))
 
   for (const match of matches) {
-    const alternates = alternatesForEntry(match.localePaths, match.params, basePath, i18n)
+    const alternates = alternatesForEntry(match.localePaths, match.params, i18n, context)
     if (alternates)
       return alternates
   }
@@ -272,16 +421,25 @@ function alternatesFromPages(basePath: string, locale: string, i18n: RuntimeI18n
  * locale prefix — `/about` and `/fr/a-propos` are the same page — so the route
  * table is consulted first and prefix arithmetic is the fallback.
  */
-export function computeLocaleAlternates(route: string, i18n: RuntimeI18nConfig): LocaleAlternate[] {
-  const { locale, basePath } = resolveLocaleFromRoute(route, i18n)
+export function computeLocaleAlternates(
+  route: string,
+  i18n: RuntimeI18nConfig,
+  context: RuntimeRouteContext = {},
+): LocaleAlternate[] {
+  const { locale, basePath } = resolveLocaleFromRoute(route, i18n, context)
+  const { pathname, suffix } = splitRouteSuffix(basePath)
 
-  const translated = alternatesFromPages(basePath, locale, i18n)
+  const translated = alternatesFromPages(pathname, locale, i18n, context)
   if (translated)
-    return translated
+    return translated.map(alternate => ({ ...alternate, path: `${alternate.path}${suffix}` }))
 
-  return i18n.locales.map(l => ({
-    code: l.code,
-    hreflang: l.hreflang || l.code,
-    path: localePath(basePath, l.code, i18n),
-  }))
+  return i18n.locales.map((l) => {
+    const domain = resolveLocaleDomain(l)
+    return {
+      code: l.code,
+      hreflang: l.hreflang || l.code,
+      path: localePath(basePath, l.code, i18n, { host: domain || context.host }),
+      ...(domain ? { domain } : {}),
+    }
+  })
 }

--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -1,0 +1,287 @@
+/**
+ * Runtime-safe i18n route resolution.
+ *
+ * `./i18n` reaches for `@nuxt/kit` to read the installed module's options, so it
+ * can only run at build time. This entry carries no build-time dependencies and
+ * is importable from a module's runtime (nitro handlers, plugins, composables).
+ * Feed it the config `toRuntimeI18nConfig()` produces.
+ */
+
+/**
+ * Custom route paths keyed by route name, then locale code — i18n's `pages`
+ * option (`globalLocaleRoutes` for nuxt-i18n-micro). `false` means the page is
+ * disabled for that locale.
+ *
+ * ```
+ * { about: { en: '/about', fr: '/a-propos' } }
+ * ```
+ */
+export type LocalePages = Record<string, Record<string, string | false> | undefined>
+
+/** Runtime-safe subset of `AutoI18nConfig` used for route locale resolution. */
+export interface RuntimeI18nConfig {
+  defaultLocale: string
+  strategy: 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
+  locales: Array<{
+    code: string
+    hreflang: string
+    name?: string
+    nativeName?: string
+  }>
+  /** Translated route paths, when i18n is configured with custom routes. */
+  pages?: LocalePages
+}
+
+export interface LocaleAlternate {
+  code: string
+  hreflang: string
+  path: string
+}
+
+export interface RouteLocaleInfo {
+  /** Resolved locale code for this route */
+  locale: string
+  /** Route with locale prefix stripped (e.g. /fr/about → /about). For no_prefix this equals route. */
+  basePath: string
+}
+
+/**
+ * Resolve which locale a route belongs to and the locale-stripped base path.
+ */
+export function resolveLocaleFromRoute(route: string, i18n: RuntimeI18nConfig): RouteLocaleInfo {
+  if (i18n.strategy === 'no_prefix')
+    return { locale: i18n.defaultLocale, basePath: route }
+
+  const segments = route.split('/').filter(Boolean)
+  const first = segments[0]
+  const matched = first ? i18n.locales.find(l => l.code === first) : undefined
+
+  if (matched) {
+    const rest = segments.slice(1).join('/')
+    return { locale: matched.code, basePath: rest ? `/${rest}` : '/' }
+  }
+
+  return { locale: i18n.defaultLocale, basePath: route }
+}
+
+/**
+ * Build the URL path for a base path under a given locale, honoring the i18n strategy.
+ */
+export function localePath(basePath: string, locale: string, i18n: RuntimeI18nConfig): string {
+  if (i18n.strategy === 'no_prefix')
+    return basePath
+
+  const isDefault = locale === i18n.defaultLocale
+  if (i18n.strategy === 'prefix_except_default' && isDefault)
+    return basePath
+
+  // prefix, prefix_and_default, prefix_except_default (non-default)
+  if (basePath === '/' || basePath === '')
+    return `/${locale}`
+  return `/${locale}${basePath}`
+}
+
+function toSegments(path: string): string[] {
+  return path.split('/').filter(Boolean)
+}
+
+interface PageParam {
+  name: string
+  catchAll: boolean
+  optional: boolean
+}
+
+/**
+ * Read a dynamic segment: `[slug]`, `[[slug]]`, `[...slug]`, `[[...slug]]` and
+ * the router equivalents `:slug`, `:slug?`, `:slug(.*)`.
+ */
+function readParam(segment: string): PageParam | null {
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    let name = segment.slice(1, -1)
+    let optional = false
+    if (name.startsWith('[') && name.endsWith(']')) {
+      name = name.slice(1, -1)
+      optional = true
+    }
+    const catchAll = name.startsWith('...')
+    if (catchAll)
+      name = name.slice(3)
+    // Anything still carrying a bracket isn't a segment we understand.
+    if (!name || name.includes('[') || name.includes(']'))
+      return null
+    return { name, catchAll, optional }
+  }
+  const colon = /^:([^(?*+]+)([?*+])?(\(\.\*\))?$/.exec(segment)
+  if (colon)
+    return { name: colon[1]!, catchAll: !!colon[3] || colon[2] === '*', optional: colon[2] === '?' || colon[2] === '*' }
+  return null
+}
+
+/**
+ * Specificity of each segment, most specific first: static beats a param, a
+ * param beats a catch-all. Mirrors how the router itself ranks routes, so the
+ * order entries happen to be declared in doesn't decide which page a path
+ * belongs to.
+ */
+function segmentRanks(pattern: string): number[] {
+  return toSegments(pattern).map((segment) => {
+    const param = readParam(segment)
+    if (!param)
+      return 2
+    return param.catchAll ? 0 : 1
+  })
+}
+
+/** Negative when `a` is more specific than `b`, for use as a sort comparator. */
+function compareSpecificity(a: number[], b: number[]): number {
+  const length = Math.max(a.length, b.length)
+  for (let i = 0; i < length; i++) {
+    // A pattern that ran out of segments is the less specific of the two.
+    const diff = (b[i] ?? -1) - (a[i] ?? -1)
+    if (diff !== 0)
+      return diff
+  }
+  return 0
+}
+
+/**
+ * Match a route pattern from the pages map against a concrete path, capturing
+ * dynamic segments. Returns null when the path belongs to a different route.
+ */
+function matchPagePattern(pattern: string, path: string): Record<string, string> | null {
+  const patternSegments = toSegments(pattern)
+  const pathSegments = toSegments(path)
+  const params: Record<string, string> = {}
+
+  for (let i = 0; i < patternSegments.length; i++) {
+    const param = readParam(patternSegments[i]!)
+    if (param?.catchAll) {
+      const rest = pathSegments.slice(i)
+      if (!rest.length)
+        return param.optional ? params : null
+      params[param.name] = rest.join('/')
+      return params
+    }
+    const segment = pathSegments[i]
+    if (segment === undefined) {
+      // The path stopped early: fine only if every segment left is optional.
+      return patternSegments.slice(i).every(s => readParam(s)?.optional) ? params : null
+    }
+    if (param)
+      params[param.name] = segment
+    else if (patternSegments[i] !== segment)
+      return null
+  }
+
+  return pathSegments.length === patternSegments.length ? params : null
+}
+
+/** Render a pattern with captured params. Null when a param has no value. */
+function fillPagePattern(pattern: string, params: Record<string, string>): string | null {
+  const filled: string[] = []
+  for (const segment of toSegments(pattern)) {
+    const param = readParam(segment)
+    if (!param) {
+      filled.push(segment)
+      continue
+    }
+    const value = params[param.name]
+    if (value === undefined) {
+      if (param.optional)
+        continue
+      return null
+    }
+    filled.push(value)
+  }
+  return filled.length ? `/${filled.join('/')}` : '/'
+}
+
+/**
+ * Build the alternates for one matched entry, or null when a locale the entry
+ * does name can't be rendered from the captured params.
+ */
+function alternatesForEntry(
+  localePaths: Record<string, string | false>,
+  params: Record<string, string>,
+  basePath: string,
+  i18n: RuntimeI18nConfig,
+): LocaleAlternate[] | null {
+  // Locales the entry doesn't name keep the untranslated route path, which the
+  // table doesn't record. The default locale's pattern is the closest thing to
+  // it we have; without one, fall back to the path that was requested.
+  const untranslated = localePaths[i18n.defaultLocale]
+  const alternates: LocaleAlternate[] = []
+
+  for (const l of i18n.locales) {
+    const pattern = localePaths[l.code] ?? untranslated
+    // Disabled for this locale: no page, so no alternate.
+    if (localePaths[l.code] === false)
+      continue
+    const path = typeof pattern === 'string' ? fillPagePattern(pattern, params) : basePath
+    if (path === null)
+      return null
+    alternates.push({
+      code: l.code,
+      hreflang: l.hreflang || l.code,
+      path: localePath(path, l.code, i18n),
+    })
+  }
+
+  return alternates
+}
+
+/**
+ * Resolve alternates from the translated route table.
+ *
+ * Returns null when the pages map can't answer for this route, in which case
+ * the caller falls back to locale-prefix arithmetic.
+ */
+function alternatesFromPages(basePath: string, locale: string, i18n: RuntimeI18nConfig): LocaleAlternate[] | null {
+  // no_prefix gives every locale the same single URL, so there is nothing to
+  // translate between.
+  const pages = i18n.pages
+  if (!pages || i18n.strategy === 'no_prefix')
+    return null
+
+  const matches: Array<{ ranks: number[], localePaths: Record<string, string | false>, params: Record<string, string> }> = []
+  for (const localePaths of Object.values(pages)) {
+    const pattern = localePaths?.[locale]
+    if (!pattern)
+      continue
+    const params = matchPagePattern(pattern, basePath)
+    if (params)
+      matches.push({ ranks: segmentRanks(pattern), localePaths, params })
+  }
+
+  matches.sort((a, b) => compareSpecificity(a.ranks, b.ranks))
+
+  for (const match of matches) {
+    const alternates = alternatesForEntry(match.localePaths, match.params, basePath, i18n)
+    if (alternates)
+      return alternates
+  }
+
+  return null
+}
+
+/**
+ * Compute hreflang alternates for a given route.
+ * Returns the route itself plus all sibling locale variants.
+ *
+ * Translated slugs (i18n `pages`) can't be derived by adding or removing a
+ * locale prefix — `/about` and `/fr/a-propos` are the same page — so the route
+ * table is consulted first and prefix arithmetic is the fallback.
+ */
+export function computeLocaleAlternates(route: string, i18n: RuntimeI18nConfig): LocaleAlternate[] {
+  const { locale, basePath } = resolveLocaleFromRoute(route, i18n)
+
+  const translated = alternatesFromPages(basePath, locale, i18n)
+  if (translated)
+    return translated
+
+  return i18n.locales.map(l => ({
+    code: l.code,
+    hreflang: l.hreflang || l.code,
+    path: localePath(basePath, l.code, i18n),
+  }))
+}

--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -47,6 +47,10 @@ export interface LocaleAlternate {
   domain?: string
 }
 
+export type LocaleAlternateResolution
+  = | { _tag: 'pages', alternates: LocaleAlternate[] }
+    | { _tag: 'strategy', alternates: LocaleAlternate[] }
+
 export interface RouteLocaleInfo {
   /** Resolved locale code for this route */
   locale: string
@@ -57,6 +61,8 @@ export interface RouteLocaleInfo {
 export interface RuntimeRouteContext {
   /** Request host, used to resolve locales under domain-based strategies. */
   host?: string
+  /** Known current locale, required to translate no_prefix routes without a locale domain. */
+  locale?: string
 }
 
 function normalizeHost(value: string): string {
@@ -111,8 +117,11 @@ export function resolveLocaleFromRoute(route: string, i18n: RuntimeI18nConfig, c
     }
   }
 
+  const contextLocale = context.locale
+    ? i18n.locales.find(locale => locale.code === context.locale)
+    : undefined
   const domainLocale = resolveLocaleFromHost(context.host, i18n)
-  return { locale: domainLocale?.code || i18n.defaultLocale, basePath: `${pathname}${suffix}` }
+  return { locale: contextLocale?.code || domainLocale?.code || i18n.defaultLocale, basePath: `${pathname}${suffix}` }
 }
 
 /**
@@ -389,7 +398,8 @@ function alternatesFromPages(
 ): LocaleAlternate[] | null {
   const pages = i18n.pages
   const hasDomainLocales = i18n.differentDomains || i18n.multiDomainLocales
-  if (!pages || (i18n.strategy === 'no_prefix' && !hasDomainLocales))
+  const hasContextLocale = !!context.locale && i18n.locales.some(locale => locale.code === context.locale)
+  if (!pages || (i18n.strategy === 'no_prefix' && !hasDomainLocales && !hasContextLocale))
     return null
 
   const matches: Array<{ ranks: number[], localePaths: Record<string, string | false>, params: Record<string, string> }> = []
@@ -421,25 +431,40 @@ function alternatesFromPages(
  * locale prefix — `/about` and `/fr/a-propos` are the same page — so the route
  * table is consulted first and prefix arithmetic is the fallback.
  */
+export function resolveLocaleAlternates(
+  route: string,
+  i18n: RuntimeI18nConfig,
+  context: RuntimeRouteContext = {},
+): LocaleAlternateResolution {
+  const { locale, basePath } = resolveLocaleFromRoute(route, i18n, context)
+  const { pathname, suffix } = splitRouteSuffix(basePath)
+
+  const translated = alternatesFromPages(pathname, locale, i18n, context)
+  if (translated) {
+    return {
+      _tag: 'pages',
+      alternates: translated.map(alternate => ({ ...alternate, path: `${alternate.path}${suffix}` })),
+    }
+  }
+
+  return {
+    _tag: 'strategy',
+    alternates: i18n.locales.map((l) => {
+      const domain = resolveLocaleDomain(l)
+      return {
+        code: l.code,
+        hreflang: l.hreflang || l.code,
+        path: localePath(basePath, l.code, i18n, { host: domain || context.host }),
+        ...(domain ? { domain } : {}),
+      }
+    }),
+  }
+}
+
 export function computeLocaleAlternates(
   route: string,
   i18n: RuntimeI18nConfig,
   context: RuntimeRouteContext = {},
 ): LocaleAlternate[] {
-  const { locale, basePath } = resolveLocaleFromRoute(route, i18n, context)
-  const { pathname, suffix } = splitRouteSuffix(basePath)
-
-  const translated = alternatesFromPages(pathname, locale, i18n, context)
-  if (translated)
-    return translated.map(alternate => ({ ...alternate, path: `${alternate.path}${suffix}` }))
-
-  return i18n.locales.map((l) => {
-    const domain = resolveLocaleDomain(l)
-    return {
-      code: l.code,
-      hreflang: l.hreflang || l.code,
-      path: localePath(basePath, l.code, i18n, { host: domain || context.host }),
-      ...(domain ? { domain } : {}),
-    }
-  })
+  return resolveLocaleAlternates(route, i18n, context).alternates
 }

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -67,7 +67,7 @@ export function splitPathForI18nLocales(path: string, autoI18n: AutoI18nConfig):
   if (!path || path.startsWith('/_'))
     return path
 
-  const localeCodes = new Set(selectedLocales.map(locale => locale.code))
+  const localeCodes = new Set<string>(selectedLocales.map(locale => locale.code))
   const runtimeI18n = toRuntimeI18nConfig(autoI18n)
   const i18n = {
     ...runtimeI18n,
@@ -157,10 +157,10 @@ export function mapPathForI18nPages(path: string, autoI18n: AutoI18nConfig): str
   const materializedPages = Object.fromEntries(
     Object.entries(pages).map(([pageName, pageLocales]) => [
       pageName,
-      Object.fromEntries(autoI18n.locales.map(locale => [
-        locale.code,
-        locale.code in pageLocales ? pageLocales[locale.code] : `/${pageName}`,
-      ])),
+      Object.fromEntries(autoI18n.locales.map((locale) => {
+        const configuredPath = pageLocales[locale.code]
+        return [locale.code, configuredPath === undefined ? `/${pageName}` : configuredPath]
+      })),
     ]),
   )
   const i18n = toRuntimeI18nConfig({

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -1,11 +1,13 @@
 import type { LocaleObject, NuxtI18nOptions } from '@nuxtjs/i18n'
 import type { RuntimeI18nConfig } from './i18n-runtime'
 import { getNuxtModuleVersion, hasNuxtModule, hasNuxtModuleCompatibility } from '@nuxt/kit'
-import { joinURL, withBase, withHttps, withLeadingSlash } from 'ufo'
+import { withBase, withHttps } from 'ufo'
+import { localePath, resolveLocaleAlternates, resolveLocaleFromRoute } from './i18n-runtime'
 import { getNuxtModuleOptions } from './kit'
 
 export type {
   LocaleAlternate,
+  LocaleAlternateResolution,
   LocalePages,
   RouteLocaleInfo,
   RuntimeI18nConfig,
@@ -15,8 +17,6 @@ export type {
 
 const I18N_MODULES = ['@nuxtjs/i18n', 'nuxt-i18n-micro'] as const
 type I18nModuleName = typeof I18N_MODULES[number]
-
-const SLASH_PATTERN = /^\/|\/$/g
 
 export type Strategies = 'no_prefix' | 'prefix_except_default' | 'prefix' | 'prefix_and_default'
 
@@ -48,32 +48,42 @@ export interface StrategyProps {
 export function generatePathForI18nPages(ctx: StrategyProps): string {
   const { localeCode, pageLocales, nuxtI18nConfig, forcedStrategy, normalisedLocales } = ctx
   const locale = normalisedLocales.find(l => l.code === localeCode)
-  let path = pageLocales
-  switch (forcedStrategy ?? nuxtI18nConfig.strategy) {
-    case 'prefix_except_default':
-    case 'prefix_and_default':
-      path = localeCode === nuxtI18nConfig.defaultLocale ? pageLocales : joinURL(localeCode, pageLocales)
-      break
-    case 'prefix':
-      path = joinURL(localeCode, pageLocales)
-      break
-  }
+  const strategy = forcedStrategy ?? nuxtI18nConfig.strategy as Strategies
+  const i18n = toRuntimeI18nConfig({
+    defaultLocale: nuxtI18nConfig.defaultLocale!,
+    locales: normalisedLocales,
+    strategy: strategy === 'prefix_and_default' ? 'prefix_except_default' : strategy,
+  })
+  const generated = localePath(pageLocales, localeCode, i18n)
+  const prefixed = generated === localePath(pageLocales, localeCode, { ...i18n, strategy: 'prefix' })
+  const path = prefixed ? generated.slice(1) : pageLocales
   return locale?.domain ? withHttps(withBase(path, locale.domain)) : path
 }
 
 export function splitPathForI18nLocales(path: string, autoI18n: AutoI18nConfig): string | string[] {
-  const locales = autoI18n.strategy === 'prefix_except_default'
+  const selectedLocales = autoI18n.strategy === 'prefix_except_default'
     ? autoI18n.locales.filter(l => l.code !== autoI18n.defaultLocale)
     : autoI18n.locales
   if (!path || path.startsWith('/_'))
     return path
 
-  const hasLocalePrefix = locales.some(l => path.startsWith(`/${l.code}/`) || path === `/${l.code}`)
+  const localeCodes = new Set(selectedLocales.map(locale => locale.code))
+  const runtimeI18n = toRuntimeI18nConfig(autoI18n)
+  const i18n = {
+    ...runtimeI18n,
+    strategy: 'prefix' as const,
+    locales: runtimeI18n.locales.filter(locale => localeCodes.has(locale.code)),
+  }
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  const resolved = resolveLocaleFromRoute(normalizedPath, i18n)
+  const hasLocalePrefix = i18n.locales.some(l =>
+    l.code === resolved.locale && localePath(resolved.basePath, l.code, i18n) === normalizedPath,
+  )
   if (hasLocalePrefix)
     return path
   return [
     path,
-    ...locales.map(l => `/${l.code}${path}`),
+    ...i18n.locales.map(l => localePath(path, l.code, i18n)),
   ]
 }
 
@@ -144,44 +154,31 @@ export function mapPathForI18nPages(path: string, autoI18n: AutoI18nConfig): str
   if (!pages || !Object.keys(pages).length)
     return false
 
-  const withoutSlashes = path.replace(SLASH_PATTERN, '').replace('/index', '')
+  const materializedPages = Object.fromEntries(
+    Object.entries(pages).map(([pageName, pageLocales]) => [
+      pageName,
+      Object.fromEntries(autoI18n.locales.map(locale => [
+        locale.code,
+        locale.code in pageLocales ? pageLocales[locale.code] : `/${pageName}`,
+      ])),
+    ]),
+  )
+  const i18n = toRuntimeI18nConfig({
+    ...autoI18n,
+    strategy: autoI18n.strategy === 'prefix_and_default' ? 'prefix_except_default' : autoI18n.strategy,
+    pages: materializedPages,
+  })
+  const resolved = resolveLocaleAlternates(path, i18n, autoI18n.strategy === 'no_prefix'
+    ? { locale: autoI18n.defaultLocale }
+    : {})
+  if (resolved._tag === 'strategy')
+    return false
 
-  function resolveForAllLocales(pageName: string, pageLocales: Record<string, string | false>): string[] {
-    return autoI18n.locales
-      .filter((l) => {
-        if (l.code in pageLocales && pageLocales[l.code] === false)
-          return false
-        if (autoI18n.strategy === 'prefix_except_default' && l.code === autoI18n.defaultLocale)
-          return false
-        return true
-      })
-      .map((l) => {
-        const localePath = (l.code in pageLocales && pageLocales[l.code] !== false)
-          ? pageLocales[l.code] as string
-          : `/${pageName}`
-        return withLeadingSlash(generatePathForI18nPages({
-          localeCode: l.code,
-          pageLocales: localePath,
-          nuxtI18nConfig: { strategy: autoI18n.strategy, defaultLocale: autoI18n.defaultLocale } as NuxtI18nOptions,
-          normalisedLocales: autoI18n.locales,
-        }))
-      })
-  }
-
-  if (withoutSlashes in pages) {
-    const pageLocales = pages[withoutSlashes]
-    if (pageLocales)
-      return resolveForAllLocales(withoutSlashes, pageLocales)
-  }
-
-  for (const [pageName, pageLocales] of Object.entries(pages)) {
-    if (!pageLocales)
-      continue
-    if (autoI18n.defaultLocale in pageLocales && pageLocales[autoI18n.defaultLocale] === path)
-      return resolveForAllLocales(pageName, pageLocales)
-  }
-
-  return false
+  return resolved.alternates
+    .filter(alternate => autoI18n.strategy !== 'prefix_except_default' || alternate.code !== autoI18n.defaultLocale)
+    .map(alternate => alternate.domain
+      ? withHttps(withBase(alternate.path, alternate.domain))
+      : alternate.path)
 }
 
 export interface I18nModuleResolution {

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -4,7 +4,14 @@ import { getNuxtModuleVersion, hasNuxtModule, hasNuxtModuleCompatibility } from 
 import { joinURL, withBase, withHttps, withLeadingSlash } from 'ufo'
 import { getNuxtModuleOptions } from './kit'
 
-export type { LocaleAlternate, LocalePages, RouteLocaleInfo, RuntimeI18nConfig } from './i18n-runtime'
+export type {
+  LocaleAlternate,
+  LocalePages,
+  RouteLocaleInfo,
+  RuntimeI18nConfig,
+  RuntimeLocale,
+  RuntimeRouteContext,
+} from './i18n-runtime'
 
 const I18N_MODULES = ['@nuxtjs/i18n', 'nuxt-i18n-micro'] as const
 type I18nModuleName = typeof I18N_MODULES[number]
@@ -20,6 +27,7 @@ export interface AutoI18nConfig {
   defaultLocale: string
   strategy: Strategies
   differentDomains?: boolean
+  multiDomainLocales?: boolean
   pages?: Record<string, Record<string, string | false>>
 }
 
@@ -225,12 +233,16 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
   const normalisedLocales = normalizeLocales(nuxtI18nConfig)
   const pages = resolveI18nPages(nuxtI18nConfig, i18n.isMicro)
   const usingI18nPages = Object.keys(pages || {}).length
-  const hasI18nConfigForAlternatives = nuxtI18nConfig.differentDomains || usingI18nPages || (nuxtI18nConfig.strategy !== 'no_prefix' && nuxtI18nConfig.locales)
+  const hasI18nConfigForAlternatives = nuxtI18nConfig.differentDomains
+    || nuxtI18nConfig.multiDomainLocales
+    || usingI18nPages
+    || (nuxtI18nConfig.strategy !== 'no_prefix' && nuxtI18nConfig.locales)
   if (!hasI18nConfigForAlternatives)
     return false
 
   return {
     differentDomains: nuxtI18nConfig.differentDomains,
+    multiDomainLocales: nuxtI18nConfig.multiDomainLocales,
     defaultLocale: nuxtI18nConfig.defaultLocale!,
     locales: normalisedLocales,
     strategy: nuxtI18nConfig.strategy as Strategies,
@@ -247,17 +259,30 @@ export function toRuntimeI18nConfig(auto: AutoI18nConfig): RuntimeI18nConfig {
   return {
     defaultLocale: auto.defaultLocale,
     strategy: auto.strategy,
+    ...(auto.differentDomains ? { differentDomains: true } : {}),
+    ...(auto.multiDomainLocales ? { multiDomainLocales: true } : {}),
     // Translated route paths. Without these the runtime can only guess
     // alternates by adding/removing a locale prefix, which is wrong for every
     // page whose slug differs per locale.
     ...(auto.pages && Object.keys(auto.pages).length ? { pages: auto.pages } : {}),
     locales: auto.locales.map((l) => {
-      const raw = l as typeof l & { name?: string, nativeName?: string, language?: string }
+      const raw = l as typeof l & {
+        name?: string
+        nativeName?: string
+        language?: string
+        domain?: string
+        domains?: string[]
+        defaultForDomains?: string[]
+      }
       return {
         code: l.code,
         hreflang: l._hreflang || raw.language || l.code,
         name: raw.name,
         nativeName: raw.nativeName ?? raw.name,
+        ...(raw.language ? { language: raw.language } : {}),
+        ...(raw.domain ? { domain: raw.domain } : {}),
+        ...(raw.domains?.length ? { domains: [...raw.domains] } : {}),
+        ...(raw.defaultForDomains?.length ? { defaultForDomains: [...raw.defaultForDomains] } : {}),
       }
     }),
   }

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -1,7 +1,10 @@
 import type { LocaleObject, NuxtI18nOptions } from '@nuxtjs/i18n'
+import type { RuntimeI18nConfig } from './i18n-runtime'
 import { getNuxtModuleVersion, hasNuxtModule, hasNuxtModuleCompatibility } from '@nuxt/kit'
 import { joinURL, withBase, withHttps, withLeadingSlash } from 'ufo'
 import { getNuxtModuleOptions } from './kit'
+
+export type { LocaleAlternate, LocalePages, RouteLocaleInfo, RuntimeI18nConfig } from './i18n-runtime'
 
 const I18N_MODULES = ['@nuxtjs/i18n', 'nuxt-i18n-micro'] as const
 type I18nModuleName = typeof I18N_MODULES[number]
@@ -232,6 +235,31 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
     locales: normalisedLocales,
     strategy: nuxtI18nConfig.strategy as Strategies,
     pages,
+  }
+}
+
+/**
+ * Strip a build-time i18n config down to what `./i18n-runtime` needs, dropping
+ * the non-serializable `LocaleObject` extras so it can be handed to the runtime
+ * through `runtimeConfig`.
+ */
+export function toRuntimeI18nConfig(auto: AutoI18nConfig): RuntimeI18nConfig {
+  return {
+    defaultLocale: auto.defaultLocale,
+    strategy: auto.strategy,
+    // Translated route paths. Without these the runtime can only guess
+    // alternates by adding/removing a locale prefix, which is wrong for every
+    // page whose slug differs per locale.
+    ...(auto.pages && Object.keys(auto.pages).length ? { pages: auto.pages } : {}),
+    locales: auto.locales.map((l) => {
+      const raw = l as typeof l & { name?: string, nativeName?: string, language?: string }
+      return {
+        code: l.code,
+        hreflang: l._hreflang || raw.language || l.code,
+        name: raw.name,
+        nativeName: raw.nativeName ?? raw.name,
+      }
+    }),
   }
 }
 

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -2,7 +2,7 @@ import type { AutoI18nConfig } from '../../src/i18n'
 import type { RuntimeI18nConfig } from '../../src/i18n-runtime'
 import { describe, expect, it } from 'vitest'
 import { toRuntimeI18nConfig } from '../../src/i18n'
-import { computeLocaleAlternates, localePath, resolveLocaleFromRoute } from '../../src/i18n-runtime'
+import { computeLocaleAlternates, localePath, resolveLocaleAlternates, resolveLocaleFromRoute } from '../../src/i18n-runtime'
 
 const en = { code: 'en', hreflang: 'en' }
 const fr = { code: 'fr', hreflang: 'fr-FR' }
@@ -86,6 +86,16 @@ describe('localePath', () => {
 })
 
 describe('computeLocaleAlternates', () => {
+  it('reports whether translated pages or strategy arithmetic resolved the route', () => {
+    expect(resolveLocaleAlternates('/about', prefixExceptDefault)._tag).toBe('strategy')
+    expect(resolveLocaleAlternates('/about', {
+      ...prefixExceptDefault,
+      pages: {
+        about: { en: '/about', fr: '/a-propos' },
+      },
+    })._tag).toBe('pages')
+  })
+
   it('prefixes when no route table is configured', () => {
     expect(paths('/about', prefixExceptDefault)).toEqual(['/about', '/fr/about'])
   })
@@ -313,6 +323,8 @@ describe('computeLocaleAlternates with translated routes', () => {
       pages: { about: { en: '/about', fr: '/a-propos' } },
     }
     expect(paths('/about', single)).toEqual(['/about', '/about'])
+    expect(computeLocaleAlternates('/about', single, { locale: 'en' }).map(alternate => alternate.path))
+      .toEqual(['/about', '/a-propos'])
   })
 })
 

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -29,9 +29,30 @@ describe('resolveLocaleFromRoute', () => {
     expect(resolveLocaleFromRoute('/fr', prefixExceptDefault)).toEqual({ locale: 'fr', basePath: '/' })
   })
 
+  it('resolves prefixes without treating query or hash text as route segments', () => {
+    expect(resolveLocaleFromRoute('/fr/about?preview=true#intro', prefixExceptDefault))
+      .toEqual({ locale: 'fr', basePath: '/about?preview=true#intro' })
+    expect(resolveLocaleFromRoute('/fr?preview=true', prefixExceptDefault))
+      .toEqual({ locale: 'fr', basePath: '/?preview=true' })
+  })
+
   it('never strips a prefix under no_prefix', () => {
     const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, strategy: 'no_prefix' }
     expect(resolveLocaleFromRoute('/fr/about', i18n)).toEqual({ locale: 'en', basePath: '/fr/about' })
+  })
+
+  it('resolves no-prefix locales from their request host', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'no_prefix',
+      differentDomains: true,
+      locales: [
+        { ...en, domain: 'https://example.com' },
+        { ...fr, domain: 'fr.example.com' },
+      ],
+    }
+    expect(resolveLocaleFromRoute('/about', i18n, { host: 'fr.example.com' }))
+      .toEqual({ locale: 'fr', basePath: '/about' })
   })
 })
 
@@ -41,10 +62,26 @@ describe('localePath', () => {
     expect(localePath('/about', 'fr', prefixExceptDefault)).toBe('/fr/about')
   })
 
+  it('normalizes paths without a leading slash', () => {
+    expect(localePath('about', 'fr', prefixExceptDefault)).toBe('/fr/about')
+  })
+
   it('prefixes every locale under prefix', () => {
     const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, strategy: 'prefix' }
     expect(localePath('/about', 'en', i18n)).toBe('/en/about')
     expect(localePath('/', 'fr', i18n)).toBe('/fr')
+  })
+
+  it('leaves a domain default locale unprefixed', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      multiDomainLocales: true,
+      locales: [
+        { ...en, domains: ['example.com'] },
+        { ...fr, domains: ['fr.example.com'], defaultForDomains: ['fr.example.com'] },
+      ],
+    }
+    expect(localePath('/about', 'fr', i18n, { host: 'fr.example.com' })).toBe('/about')
   })
 })
 
@@ -78,6 +115,11 @@ describe('computeLocaleAlternates with translated routes', () => {
     ])
   })
 
+  it('translates the pathname while preserving query and hash suffixes', () => {
+    expect(paths('/about?preview=true#intro', translated))
+      .toEqual(['/about?preview=true#intro', '/fr/a-propos?preview=true#intro'])
+  })
+
   it('resolves back from a translated route to the default one', () => {
     expect(paths('/fr/a-propos', translated)).toEqual(['/about', '/fr/a-propos'])
   })
@@ -109,6 +151,49 @@ describe('computeLocaleAlternates with translated routes', () => {
 
   it('does not confuse a listing route with its detail route', () => {
     expect(paths('/blog', translated)).toEqual(['/blog', '/fr/journal'])
+  })
+
+  it('prefers an exact route over an optional sibling', () => {
+    const shadowed: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        'blog-slug': { en: '/blog/[[slug]]', fr: '/journal/[[slug]]' },
+        'blog': { en: '/blog', fr: '/articles' },
+      },
+    }
+    expect(paths('/blog', shadowed)).toEqual(['/blog', '/fr/articles'])
+  })
+
+  it('matches params embedded in static segments', () => {
+    const embedded: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        'archive-entry': { en: '/archive/[year]-[slug]', fr: '/archives/[slug]-[year]' },
+      },
+    }
+    expect(paths('/archive/2026-release-notes', embedded))
+      .toEqual(['/archive/2026-release-notes', '/fr/archives/release-notes-2026'])
+  })
+
+  it('backtracks over an omitted optional segment', () => {
+    const optional: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        editor: { en: '/articles/[[slug]]/edit', fr: '/articles/[[slug]]/modifier' },
+      },
+    }
+    expect(paths('/articles/edit', optional)).toEqual(['/articles/edit', '/fr/articles/modifier'])
+  })
+
+  it('supports Vue Router catch-all syntax', () => {
+    const catchAll: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        docs: { en: '/docs/:path(.*)*', fr: '/documentation/:path(.*)*' },
+      },
+    }
+    expect(paths('/docs/guide/getting-started', catchAll))
+      .toEqual(['/docs/guide/getting-started', '/fr/documentation/guide/getting-started'])
   })
 
   it('prefers a static entry over a dynamic one declared before it', () => {
@@ -156,12 +241,60 @@ describe('computeLocaleAlternates with translated routes', () => {
     expect(paths('/fr/a-propos', partial)).toEqual(['/about', '/fr/a-propos', '/de/about'])
   })
 
-  it('falls back to prefixing when an entry names no default locale', () => {
+  it('omits unknown locale paths when an entry names no default locale', () => {
     const partial: RuntimeI18nConfig = {
       ...prefixExceptDefault,
       pages: { about: { fr: '/a-propos' } },
     }
-    expect(paths('/fr/a-propos', partial)).toEqual(['/a-propos', '/fr/a-propos'])
+    expect(paths('/fr/a-propos', partial)).toEqual(['/fr/a-propos'])
+  })
+
+  it('exposes locale domains with alternates', () => {
+    const domains: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'no_prefix',
+      differentDomains: true,
+      locales: [
+        { ...en, domain: 'example.com' },
+        { ...fr, domain: 'fr.example.com' },
+      ],
+    }
+    expect(computeLocaleAlternates('/about', domains)).toEqual([
+      { code: 'en', hreflang: 'en', path: '/about', domain: 'example.com' },
+      { code: 'fr', hreflang: 'fr-FR', path: '/about', domain: 'fr.example.com' },
+    ])
+  })
+
+  it('uses each locale default domain as its canonical alternate domain', () => {
+    const domains: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'no_prefix',
+      multiDomainLocales: true,
+      locales: [
+        { ...en, domains: ['example.test', 'example.com'], defaultForDomains: ['example.com'] },
+        { ...fr, domains: ['example.test'], defaultForDomains: ['example.test'] },
+      ],
+    }
+    expect(computeLocaleAlternates('/about', domains, { host: 'example.test' })).toEqual([
+      { code: 'en', hreflang: 'en', path: '/about', domain: 'example.com' },
+      { code: 'fr', hreflang: 'fr-FR', path: '/about', domain: 'example.test' },
+    ])
+  })
+
+  it('translates routes across locale domains', () => {
+    const domains: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      differentDomains: true,
+      locales: [
+        { ...en, domain: 'example.com' },
+        { ...fr, domain: 'fr.example.com' },
+      ],
+      pages: { about: { en: '/about', fr: '/a-propos' } },
+    }
+    expect(computeLocaleAlternates('/a-propos', domains, { host: 'fr.example.com' })).toEqual([
+      { code: 'en', hreflang: 'en', path: '/about', domain: 'example.com' },
+      { code: 'fr', hreflang: 'fr-FR', path: '/a-propos', domain: 'fr.example.com' },
+    ])
   })
 
   it('prefixes every locale under the prefix strategy', () => {
@@ -208,5 +341,36 @@ describe('toRuntimeI18nConfig', () => {
   it('carries the route table through when present', () => {
     const pages = { about: { en: '/about', fr: '/a-propos' } }
     expect(toRuntimeI18nConfig({ ...auto, pages }).pages).toEqual(pages)
+  })
+
+  it('carries serializable domain locale metadata through', () => {
+    const config = toRuntimeI18nConfig({
+      ...auto,
+      differentDomains: true,
+      multiDomainLocales: true,
+      locales: [
+        {
+          code: 'en',
+          _hreflang: 'en-US',
+          _sitemap: 'en-US',
+          language: 'en-US',
+          domain: 'example.com',
+          domains: ['example.com', 'example.test'],
+          defaultForDomains: ['example.com'],
+        },
+      ],
+    })
+    expect(config).toMatchObject({
+      differentDomains: true,
+      multiDomainLocales: true,
+      locales: [{
+        code: 'en',
+        hreflang: 'en-US',
+        language: 'en-US',
+        domain: 'example.com',
+        domains: ['example.com', 'example.test'],
+        defaultForDomains: ['example.com'],
+      }],
+    })
   })
 })

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -1,0 +1,212 @@
+import type { AutoI18nConfig } from '../../src/i18n'
+import type { RuntimeI18nConfig } from '../../src/i18n-runtime'
+import { describe, expect, it } from 'vitest'
+import { toRuntimeI18nConfig } from '../../src/i18n'
+import { computeLocaleAlternates, localePath, resolveLocaleFromRoute } from '../../src/i18n-runtime'
+
+const en = { code: 'en', hreflang: 'en' }
+const fr = { code: 'fr', hreflang: 'fr-FR' }
+const de = { code: 'de', hreflang: 'de-DE' }
+
+const prefixExceptDefault: RuntimeI18nConfig = {
+  defaultLocale: 'en',
+  strategy: 'prefix_except_default',
+  locales: [en, fr],
+}
+
+const paths = (route: string, i18n: RuntimeI18nConfig) => computeLocaleAlternates(route, i18n).map(a => a.path)
+
+describe('resolveLocaleFromRoute', () => {
+  it('strips the prefix to find the locale', () => {
+    expect(resolveLocaleFromRoute('/fr/about', prefixExceptDefault)).toEqual({ locale: 'fr', basePath: '/about' })
+  })
+
+  it('falls back to the default locale when unprefixed', () => {
+    expect(resolveLocaleFromRoute('/about', prefixExceptDefault)).toEqual({ locale: 'en', basePath: '/about' })
+  })
+
+  it('handles a bare locale root', () => {
+    expect(resolveLocaleFromRoute('/fr', prefixExceptDefault)).toEqual({ locale: 'fr', basePath: '/' })
+  })
+
+  it('never strips a prefix under no_prefix', () => {
+    const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, strategy: 'no_prefix' }
+    expect(resolveLocaleFromRoute('/fr/about', i18n)).toEqual({ locale: 'en', basePath: '/fr/about' })
+  })
+})
+
+describe('localePath', () => {
+  it('leaves the default locale unprefixed under prefix_except_default', () => {
+    expect(localePath('/about', 'en', prefixExceptDefault)).toBe('/about')
+    expect(localePath('/about', 'fr', prefixExceptDefault)).toBe('/fr/about')
+  })
+
+  it('prefixes every locale under prefix', () => {
+    const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, strategy: 'prefix' }
+    expect(localePath('/about', 'en', i18n)).toBe('/en/about')
+    expect(localePath('/', 'fr', i18n)).toBe('/fr')
+  })
+})
+
+describe('computeLocaleAlternates', () => {
+  it('prefixes when no route table is configured', () => {
+    expect(paths('/about', prefixExceptDefault)).toEqual(['/about', '/fr/about'])
+  })
+
+  it('resolves a route the table has no entry for', () => {
+    const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, pages: { about: { en: '/about', fr: '/a-propos' } } }
+    expect(paths('/contact', i18n)).toEqual(['/contact', '/fr/contact'])
+  })
+})
+
+describe('computeLocaleAlternates with translated routes', () => {
+  const translated: RuntimeI18nConfig = {
+    ...prefixExceptDefault,
+    pages: {
+      'about': { en: '/about', fr: '/a-propos' },
+      'blog': { en: '/blog', fr: '/journal' },
+      'blog-slug': { en: '/blog/[slug]', fr: '/journal/[slug]' },
+      'docs-path': { en: '/docs/[...path]', fr: '/documentation/[...path]' },
+      'legal': { en: '/legal', fr: false },
+    },
+  }
+
+  it('uses the translated slug instead of prefixing the default one', () => {
+    expect(computeLocaleAlternates('/about', translated)).toEqual([
+      { code: 'en', hreflang: 'en', path: '/about' },
+      { code: 'fr', hreflang: 'fr-FR', path: '/fr/a-propos' },
+    ])
+  })
+
+  it('resolves back from a translated route to the default one', () => {
+    expect(paths('/fr/a-propos', translated)).toEqual(['/about', '/fr/a-propos'])
+  })
+
+  it('carries dynamic params across locales in both directions', () => {
+    expect(paths('/blog/hello-world', translated)).toEqual(['/blog/hello-world', '/fr/journal/hello-world'])
+    expect(paths('/fr/journal/hello-world', translated)).toEqual(['/blog/hello-world', '/fr/journal/hello-world'])
+  })
+
+  it('carries catch-all params across locales', () => {
+    expect(paths('/docs/guide/getting-started', translated))
+      .toEqual(['/docs/guide/getting-started', '/fr/documentation/guide/getting-started'])
+  })
+
+  it('carries optional params across locales', () => {
+    const optional: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: { 'blog-slug': { en: '/blog/[[slug]]', fr: '/journal/[[slug]]' } },
+    }
+    expect(paths('/blog/hello', optional)).toEqual(['/blog/hello', '/fr/journal/hello'])
+    expect(paths('/blog', optional)).toEqual(['/blog', '/fr/journal'])
+  })
+
+  it('omits locales the page is disabled for', () => {
+    expect(computeLocaleAlternates('/legal', translated)).toEqual([
+      { code: 'en', hreflang: 'en', path: '/legal' },
+    ])
+  })
+
+  it('does not confuse a listing route with its detail route', () => {
+    expect(paths('/blog', translated)).toEqual(['/blog', '/fr/journal'])
+  })
+
+  it('prefers a static entry over a dynamic one declared before it', () => {
+    const shadowed: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        slug: { en: '/[slug]', fr: '/[slug]' },
+        about: { en: '/about', fr: '/a-propos' },
+      },
+    }
+    expect(paths('/about', shadowed)).toEqual(['/about', '/fr/a-propos'])
+  })
+
+  it('prefers a static entry over a catch-all declared before it', () => {
+    const shadowed: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        path: { en: '/[...path]', fr: '/[...path]' },
+        about: { en: '/about', fr: '/a-propos' },
+      },
+    }
+    expect(paths('/about', shadowed)).toEqual(['/about', '/fr/a-propos'])
+  })
+
+  it('prefers a dynamic segment over a catch-all at the same depth', () => {
+    const ranked: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        'docs-path': { en: '/docs/[...path]', fr: '/documentation/[...path]' },
+        'docs-slug': { en: '/docs/[slug]', fr: '/doc/[slug]' },
+      },
+    }
+    expect(paths('/docs/intro', ranked)).toEqual(['/docs/intro', '/fr/doc/intro'])
+    expect(paths('/docs/guide/intro', ranked)).toEqual(['/docs/guide/intro', '/fr/documentation/guide/intro'])
+  })
+
+  it('keeps translations for the locales an entry does name', () => {
+    const partial: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      locales: [en, fr, de],
+      pages: { about: { en: '/about', fr: '/a-propos' } },
+    }
+    // `de` is untranslated, so it keeps the default locale's path rather than
+    // the requested `/a-propos`, which exists only under `fr`.
+    expect(paths('/fr/a-propos', partial)).toEqual(['/about', '/fr/a-propos', '/de/about'])
+  })
+
+  it('falls back to prefixing when an entry names no default locale', () => {
+    const partial: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: { about: { fr: '/a-propos' } },
+    }
+    expect(paths('/fr/a-propos', partial)).toEqual(['/a-propos', '/fr/a-propos'])
+  })
+
+  it('prefixes every locale under the prefix strategy', () => {
+    const prefixed: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'prefix',
+      pages: { about: { en: '/about', fr: '/a-propos' } },
+    }
+    expect(paths('/en/about', prefixed)).toEqual(['/en/about', '/fr/a-propos'])
+  })
+
+  it('ignores the table under no_prefix, where each page has one URL', () => {
+    const single: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'no_prefix',
+      pages: { about: { en: '/about', fr: '/a-propos' } },
+    }
+    expect(paths('/about', single)).toEqual(['/about', '/about'])
+  })
+})
+
+describe('toRuntimeI18nConfig', () => {
+  const auto: AutoI18nConfig = {
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    locales: [
+      { code: 'en', _hreflang: 'en-US', _sitemap: 'en-US' },
+      { code: 'fr', _hreflang: 'fr-FR', _sitemap: 'fr-FR' },
+    ],
+  }
+
+  it('carries hreflang off the normalised locale', () => {
+    expect(toRuntimeI18nConfig(auto).locales).toEqual([
+      { code: 'en', hreflang: 'en-US', name: undefined, nativeName: undefined },
+      { code: 'fr', hreflang: 'fr-FR', name: undefined, nativeName: undefined },
+    ])
+  })
+
+  it('omits pages when the route table is empty', () => {
+    expect(toRuntimeI18nConfig(auto)).not.toHaveProperty('pages')
+    expect(toRuntimeI18nConfig({ ...auto, pages: {} })).not.toHaveProperty('pages')
+  })
+
+  it('carries the route table through when present', () => {
+    const pages = { about: { en: '/about', fr: '/a-propos' } }
+    expect(toRuntimeI18nConfig({ ...auto, pages }).pages).toEqual(pages)
+  })
+})

--- a/packages/shared/test/unit/i18n.test.ts
+++ b/packages/shared/test/unit/i18n.test.ts
@@ -226,6 +226,11 @@ describe('splitPathForI18nLocales', () => {
     expect(result).toEqual(['/about', '/fr/about', '/es/about'])
   })
 
+  it('normalizes locale variants when the input omits its leading slash', () => {
+    const config = makeAutoI18n()
+    expect(splitPathForI18nLocales('about', config)).toEqual(['about', '/fr/about', '/es/about'])
+  })
+
   it('returns path as-is when it already has a locale prefix', () => {
     const config = makeAutoI18n()
     const result = splitPathForI18nLocales('/fr/about', config)
@@ -377,5 +382,32 @@ describe('mapPathForI18nPages', () => {
     })
     const result = mapPathForI18nPages('/about/', config)
     expect(result).toBeInstanceOf(Array)
+  })
+
+  it('maps dynamic translated paths through the runtime route matcher', () => {
+    const config = makeAutoI18n({
+      pages: {
+        'posts-slug': {
+          en: '/posts/[slug]',
+          fr: '/articles/[slug]',
+          es: false,
+        },
+      },
+    })
+    expect(mapPathForI18nPages('/posts/hello', config)).toEqual(['/fr/articles/hello'])
+  })
+
+  it('preserves translated paths under no_prefix', () => {
+    const config = makeAutoI18n({
+      strategy: 'no_prefix',
+      pages: {
+        about: {
+          en: '/about',
+          fr: '/a-propos',
+          es: '/acerca',
+        },
+      },
+    })
+    expect(mapPathForI18nPages('/about', config)).toEqual(['/about', '/a-propos', '/acerca'])
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No issue. Surfaced by harlan-zw/nuxt-ai-ready#71, which hit fabricated hreflang alternates in production.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [x] 👌 Enhancement
- [x] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

`./i18n` imports `@nuxt/kit`, so runtime code cannot safely import it. This adds a dependency-free `./i18n-runtime` entry with:

- `resolveLocaleFromRoute()`
- `localePath()`
- `resolveLocaleAlternates()`
- `computeLocaleAlternates()`
- serializable runtime config and locale types
- `toRuntimeI18nConfig()` in `./i18n`

The resolver covers translated slugs in both directions, static and embedded params, optional segments, catch-alls, Vue Router catch-all syntax, route specificity, disabled locales, partial page maps, query and hash suffixes, all prefix strategies, and domain locales. Unknown locale paths are omitted when the page table cannot derive them.

Domain support includes `differentDomains`, `multiDomainLocales`, `domain`, `domains`, and `defaultForDomains`. Callers can pass a request host. For `no_prefix`, callers that already know the active locale can pass `context.locale`, which lets the resolver translate routes that carry no locale signal in their URL.

`resolveLocaleAlternates()` returns a tagged `pages | strategy` result. Consumers that need fallback control can inspect the source. `computeLocaleAlternates()` remains the array-returning convenience API.

#### Shared build and runtime core

The existing build-time helpers now delegate to `./i18n-runtime` for prefixing, locale detection, and translated route matching. This removes the second implementation and fixes dynamic translated paths in `mapPathForI18nPages()` plus malformed variants when a path omits its leading slash.

The dependency direction is one way: build-time `i18n` imports the pure runtime entry. Both files are Unbuild entries, so the published `i18n.mjs` imports `./i18n-runtime.mjs` instead of inlining a second copy. `i18n-runtime.mjs` has no import from `@nuxt/kit`, `@nuxtjs/i18n`, `ufo`, or the build-time entry.

#### Runtime i18n sweep

| Module | Runtime i18n use | Coverage |
| --- | --- | --- |
| `nuxt-ai-ready` | Locale detection, translated alternates, Link headers, markdown frontmatter | Direct adopter of all runtime functions |
| `@nuxtjs/sitemap` | Translated route matching, dynamic params, domains, hreflang | Shared resolver covers route translation; sitemap keeps x-default, filtering, URL assembly, and sitemap mapping |
| `@nuxtjs/robots` | Locale stripping before route-rule lookup | Direct adopter of `resolveLocaleFromRoute()`; fixes prefix boundary errors such as `/enterprise` with locale `en` |
| `nuxt-seo-utils` | Breadcrumb locale root construction | `localePath()` covers its prefix arithmetic |
| `nuxt-schema-org` | Reactive locale paths and locale properties | Existing `useLocalePath()` integration remains appropriate |
| `nuxt-site-config` | Reactive locale, language, and base URL state | Existing runtime plugin remains appropriate |
| `nuxt-link-checker`, `nuxt-og-image`, `nuxt-skew-protection` | No runtime route localization | No adoption needed |

Adoption stays in each module repository. This PR supplies the route, parameter, strategy, suffix, locale-context, and domain data those changes need.

#### Compatibility

Existing imports remain available. The new config and context fields are optional. Routes outside the page table keep strategy arithmetic. Build-time helper output shapes remain unchanged, including `no_prefix` translated paths and the legacy unprefixed default route for `prefix_and_default`.

#### Verification

- 155 shared package tests
- Nuxt 5 and Nitro 3 compatibility fixture
- repository typecheck and build
- lint on every changed source and test file
- published output inspection for the one-way `i18n.mjs` to `i18n-runtime.mjs` dependency
- `pnpm pack` of `nuxtseo-shared@5.3.10`
- packed tarball installed into an isolated Nuxt 4.5.2 app
- fresh client, SSR, and Nitro production builds using the runtime entry from a client plugin and server handler
- live Nitro request returned translated page alternates
- consumer client and route bundles contained no build-time i18n dependencies

The standalone AI Ready snapshot fix is also on `main` as `044f62a` and merged into this branch.
