### PR TITLE
fix(shared): resolve partial i18n routes

### DIFF
--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -192,7 +192,7 @@ type PageToken = StaticPageToken | ParamPageToken
 
 // Nuxt bracket params plus the Vue Router forms i18n emits. Parsing tokens
 // instead of whole segments also covers paths such as `/archive/[year]-[slug]`.
-const PAGE_PARAM_PATTERN = /\[\[(\.\.\.)?([^[\]]+)\]\]|\[(\.\.\.)?([^[\]]+)\]|:(\w+)(?:\(((?:\\.|[^)])*)\))?([?*+]?)/g
+const PAGE_PARAM_PATTERN = /\[\[(\.\.\.)?([^[\]]+)\]\]|\[(\.\.\.)?([^[\]]+)\]|:(\w+)(?:\((\.\*)?\))?([?*+]?)/g
 
 function parsePageSegment(segment: string): PageToken[] {
   const tokens: PageToken[] = []

--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -8,15 +8,28 @@
  */
 
 /**
- * Custom route paths keyed by route name, then locale code — i18n's `pages`
- * option (`globalLocaleRoutes` for nuxt-i18n-micro). `false` means the page is
- * disabled for that locale.
+ * Resolved route paths keyed by route name, then locale code. Per-locale
+ * `false` disables that locale. A tagged unlocalized entry represents i18n's
+ * whole-route `false` after build-time materialization.
  *
  * ```
- * { about: { en: '/about', fr: '/a-propos' } }
+ * { about: { en: '/about', fr: '/a-propos' }, admin: { _tag: 'unlocalized', path: '/admin' } }
  * ```
  */
-export type LocalePages = Record<string, Record<string, string | false> | undefined>
+export type LocalePagePaths = Record<string, string | false>
+
+export interface UnlocalizedLocalePage {
+  /** Route excluded from i18n localization by a whole-route `pages` false. */
+  _tag: 'unlocalized'
+  /** Original resolved Nuxt route pattern. */
+  path: string
+}
+
+export type LocalePages = Record<string, LocalePagePaths | UnlocalizedLocalePage | undefined>
+
+function isUnlocalizedLocalePage(page: LocalePagePaths | UnlocalizedLocalePage): page is UnlocalizedLocalePage {
+  return page._tag === 'unlocalized' && typeof page.path === 'string'
+}
 
 export interface RuntimeLocale {
   code: string
@@ -179,7 +192,7 @@ type PageToken = StaticPageToken | ParamPageToken
 
 // Nuxt bracket params plus the Vue Router forms i18n emits. Parsing tokens
 // instead of whole segments also covers paths such as `/archive/[year]-[slug]`.
-const PAGE_PARAM_PATTERN = /\[\[(\.\.\.)?([^[\]]+)\]\]|\[(\.\.\.)?([^[\]]+)\]|:(\w+)(?:\((\.\*)\))?([?*+]?)/g
+const PAGE_PARAM_PATTERN = /\[\[(\.\.\.)?([^[\]]+)\]\]|\[(\.\.\.)?([^[\]]+)\]|:(\w+)(?:\(((?:\\.|[^)])*)\))?([?*+]?)/g
 
 function parsePageSegment(segment: string): PageToken[] {
   const tokens: PageToken[] = []
@@ -198,11 +211,12 @@ function parsePageSegment(segment: string): PageToken[] {
     }
     else {
       const modifier = match[7]
+      const routePattern = match[6]
       tokens.push({
         _tag: 'param',
         param: {
           name: match[5]!,
-          catchAll: !!match[6] || modifier === '*' || modifier === '+',
+          catchAll: !!routePattern?.includes('.*') || modifier === '*' || modifier === '+',
           optional: modifier === '?' || modifier === '*',
         },
       })
@@ -395,26 +409,57 @@ function alternatesFromPages(
   locale: string,
   i18n: RuntimeI18nConfig,
   context: RuntimeRouteContext,
+  allowUnlocalized: boolean,
 ): LocaleAlternate[] | null {
   const pages = i18n.pages
   const hasDomainLocales = i18n.differentDomains || i18n.multiDomainLocales
   const hasContextLocale = !!context.locale && i18n.locales.some(locale => locale.code === context.locale)
-  if (!pages || (i18n.strategy === 'no_prefix' && !hasDomainLocales && !hasContextLocale))
+  if (!pages)
+    return null
+  const hasUnlocalizedPages = Object.values(pages).some(page => page && isUnlocalizedLocalePage(page))
+  if (i18n.strategy === 'no_prefix' && !hasDomainLocales && !hasContextLocale && !hasUnlocalizedPages)
     return null
 
-  const matches: Array<{ ranks: number[], localePaths: Record<string, string | false>, params: Record<string, string> }> = []
-  for (const localePaths of Object.values(pages)) {
-    const pattern = localePaths?.[locale]
+  type PageMatch
+    = | { _tag: 'localized', ranks: number[], localePaths: LocalePagePaths, params: Record<string, string> }
+      | { _tag: 'unlocalized', ranks: number[], page: UnlocalizedLocalePage, params: Record<string, string> }
+  const matches: PageMatch[] = []
+  for (const page of Object.values(pages)) {
+    if (!page)
+      continue
+    if (isUnlocalizedLocalePage(page)) {
+      if (!allowUnlocalized)
+        continue
+      const params = matchPagePattern(page.path, basePath)
+      if (params)
+        matches.push({ _tag: 'unlocalized', ranks: segmentRanks(page.path), page, params })
+      continue
+    }
+    const pattern = page[locale]
     if (!pattern)
       continue
     const params = matchPagePattern(pattern, basePath)
     if (params)
-      matches.push({ ranks: segmentRanks(pattern), localePaths, params })
+      matches.push({ _tag: 'localized', ranks: segmentRanks(pattern), localePaths: page, params })
   }
 
   matches.sort((a, b) => compareSpecificity(a.ranks, b.ranks))
 
   for (const match of matches) {
+    if (match._tag === 'unlocalized') {
+      const path = fillPagePattern(match.page.path, match.params)
+      const defaultLocale = i18n.locales.find(locale => locale.code === i18n.defaultLocale)
+      if (path && defaultLocale) {
+        const domain = resolveLocaleDomain(defaultLocale)
+        return [{
+          code: defaultLocale.code,
+          hreflang: defaultLocale.hreflang || defaultLocale.code,
+          path,
+          ...(domain ? { domain } : {}),
+        }]
+      }
+      continue
+    }
     const alternates = alternatesForEntry(match.localePaths, match.params, i18n, context)
     if (alternates)
       return alternates
@@ -438,8 +483,9 @@ export function resolveLocaleAlternates(
 ): LocaleAlternateResolution {
   const { locale, basePath } = resolveLocaleFromRoute(route, i18n, context)
   const { pathname, suffix } = splitRouteSuffix(basePath)
+  const { pathname: routePathname } = splitRouteSuffix(route)
 
-  const translated = alternatesFromPages(pathname, locale, i18n, context)
+  const translated = alternatesFromPages(pathname, locale, i18n, context, routePathname === pathname)
   if (translated) {
     return {
       _tag: 'pages',

--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -23,12 +23,23 @@ export interface UnlocalizedLocalePage {
   _tag: 'unlocalized'
   /** Original resolved Nuxt route pattern. */
   path: string
+  /** The route has children, which i18n also leaves unlocalized. */
+  subtree?: true
 }
 
 export type LocalePages = Record<string, LocalePagePaths | UnlocalizedLocalePage | undefined>
 
 function isUnlocalizedLocalePage(page: LocalePagePaths | UnlocalizedLocalePage): page is UnlocalizedLocalePage {
   return page._tag === 'unlocalized' && typeof page.path === 'string'
+}
+
+function matchesUnlocalizedLocalePage(page: UnlocalizedLocalePage, path: string): boolean {
+  if (matchPagePattern(page.path, path))
+    return true
+  if (!page.subtree)
+    return false
+  const subtreePattern = `${page.path === '/' ? '' : page.path.replace(/\/$/, '')}/[...__nuxtSeoSubtree]`
+  return !!matchPagePattern(subtreePattern, path)
 }
 
 export interface RuntimeLocale {
@@ -126,7 +137,8 @@ export function resolveLocaleFromRoute(route: string, i18n: RuntimeI18nConfig, c
 
     if (matched) {
       const rest = segments.slice(1).join('/')
-      return { locale: matched.code, basePath: `${rest ? `/${rest}` : '/'}${suffix}` }
+      const trailingSlash = rest && pathname.endsWith('/') ? '/' : ''
+      return { locale: matched.code, basePath: `${rest ? `/${rest}${trailingSlash}` : '/'}${suffix}` }
     }
   }
 
@@ -269,15 +281,27 @@ function compareSpecificity(a: number[], b: number[]): number {
 }
 
 function matchSegmentTokens(tokens: PageToken[], path: string): Record<string, string> | null {
+  const failedStates = new Set<number>()
+
   function visit(index: number, offset: number, params: Record<string, string>): Record<string, string> | null {
-    if (index === tokens.length)
-      return offset === path.length ? params : null
+    const state = index * (path.length + 1) + offset
+    if (failedStates.has(state))
+      return null
+    if (index === tokens.length) {
+      if (offset === path.length)
+        return params
+      failedStates.add(state)
+      return null
+    }
 
     const token = tokens[index]!
     if (token._tag === 'static') {
-      return path.startsWith(token.value, offset)
+      const matched = path.startsWith(token.value, offset)
         ? visit(index + 1, offset + token.value.length, params)
         : null
+      if (!matched)
+        failedStates.add(state)
+      return matched
     }
 
     const minimumEnd = token.param.optional ? offset : offset + 1
@@ -288,6 +312,7 @@ function matchSegmentTokens(tokens: PageToken[], path: string): Record<string, s
       if (matched)
         return matched
     }
+    failedStates.add(state)
     return null
   }
 
@@ -301,10 +326,18 @@ function matchSegmentTokens(tokens: PageToken[], path: string): Record<string, s
 function matchPagePattern(pattern: string, path: string): Record<string, string> | null {
   const patternSegments = toSegments(pattern)
   const pathSegments = toSegments(path)
+  const failedStates = new Set<number>()
 
   function visit(patternIndex: number, pathIndex: number, params: Record<string, string>): Record<string, string> | null {
-    if (patternIndex === patternSegments.length)
-      return pathIndex === pathSegments.length ? params : null
+    const state = patternIndex * (pathSegments.length + 1) + pathIndex
+    if (failedStates.has(state))
+      return null
+    if (patternIndex === patternSegments.length) {
+      if (pathIndex === pathSegments.length)
+        return params
+      failedStates.add(state)
+      return null
+    }
 
     const tokens = parsePageSegment(patternSegments[patternIndex]!)
     const param = wholeSegmentParam(tokens)
@@ -317,6 +350,7 @@ function matchPagePattern(pattern: string, path: string): Record<string, string>
         if (matched)
           return matched
       }
+      failedStates.add(state)
       return null
     }
 
@@ -330,7 +364,10 @@ function matchPagePattern(pattern: string, path: string): Record<string, string>
       }
     }
 
-    return param?.optional ? visit(patternIndex + 1, pathIndex, params) : null
+    const matched = param?.optional ? visit(patternIndex + 1, pathIndex, params) : null
+    if (!matched)
+      failedStates.add(state)
+    return matched
   }
 
   return visit(0, 0, {})
@@ -358,7 +395,9 @@ function fillPagePattern(pattern: string, params: Record<string, string>): strin
     if (value)
       filled.push(value)
   }
-  return filled.length ? `/${filled.join('/')}` : '/'
+  if (!filled.length)
+    return '/'
+  return `/${filled.join('/')}${pattern.endsWith('/') ? '/' : ''}`
 }
 
 /**
@@ -406,35 +445,32 @@ function alternatesForEntry(
  */
 function alternatesFromPages(
   basePath: string,
+  routePath: string,
   locale: string,
   i18n: RuntimeI18nConfig,
   context: RuntimeRouteContext,
-  allowUnlocalized: boolean,
 ): LocaleAlternate[] | null {
   const pages = i18n.pages
   const hasDomainLocales = i18n.differentDomains || i18n.multiDomainLocales
   const hasContextLocale = !!context.locale && i18n.locales.some(locale => locale.code === context.locale)
   if (!pages)
     return null
-  const hasUnlocalizedPages = Object.values(pages).some(page => page && isUnlocalizedLocalePage(page))
-  if (i18n.strategy === 'no_prefix' && !hasDomainLocales && !hasContextLocale && !hasUnlocalizedPages)
-    return null
+  const allowLocalized = i18n.strategy !== 'no_prefix' || hasDomainLocales || hasContextLocale
 
   type PageMatch
     = | { _tag: 'localized', ranks: number[], localePaths: LocalePagePaths, params: Record<string, string> }
-      | { _tag: 'unlocalized', ranks: number[], page: UnlocalizedLocalePage, params: Record<string, string> }
+      | { _tag: 'unlocalized', ranks: number[] }
   const matches: PageMatch[] = []
   for (const page of Object.values(pages)) {
     if (!page)
       continue
     if (isUnlocalizedLocalePage(page)) {
-      if (!allowUnlocalized)
-        continue
-      const params = matchPagePattern(page.path, basePath)
-      if (params)
-        matches.push({ _tag: 'unlocalized', ranks: segmentRanks(page.path), page, params })
+      if (matchesUnlocalizedLocalePage(page, routePath))
+        matches.push({ _tag: 'unlocalized', ranks: segmentRanks(page.path) })
       continue
     }
+    if (!allowLocalized)
+      continue
     const pattern = page[locale]
     if (!pattern)
       continue
@@ -447,14 +483,13 @@ function alternatesFromPages(
 
   for (const match of matches) {
     if (match._tag === 'unlocalized') {
-      const path = fillPagePattern(match.page.path, match.params)
       const defaultLocale = i18n.locales.find(locale => locale.code === i18n.defaultLocale)
-      if (path && defaultLocale) {
+      if (defaultLocale) {
         const domain = resolveLocaleDomain(defaultLocale)
         return [{
           code: defaultLocale.code,
           hreflang: defaultLocale.hreflang || defaultLocale.code,
-          path,
+          path: routePath,
           ...(domain ? { domain } : {}),
         }]
       }
@@ -485,7 +520,9 @@ export function resolveLocaleAlternates(
   const { pathname, suffix } = splitRouteSuffix(basePath)
   const { pathname: routePathname } = splitRouteSuffix(route)
 
-  const translated = alternatesFromPages(pathname, locale, i18n, context, routePathname === pathname)
+  // Whole-route false entries were never localized, so match their raw route
+  // before locale-prefix stripping. `/fr/legal` may itself be unlocalized.
+  const translated = alternatesFromPages(pathname, routePathname, locale, i18n, context)
   if (translated) {
     return {
       _tag: 'pages',

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -1,5 +1,5 @@
 import type { LocaleObject, NuxtI18nOptions } from '@nuxtjs/i18n'
-import type { RuntimeI18nConfig } from './i18n-runtime'
+import type { RuntimeI18nConfig, UnlocalizedLocalePage } from './i18n-runtime'
 import { getNuxtModuleVersion, hasNuxtModule, hasNuxtModuleCompatibility } from '@nuxt/kit'
 import { withBase, withHttps } from 'ufo'
 import { localePath, resolveLocaleAlternates, resolveLocaleFromRoute } from './i18n-runtime'
@@ -8,11 +8,13 @@ import { getNuxtModuleOptions } from './kit'
 export type {
   LocaleAlternate,
   LocaleAlternateResolution,
+  LocalePagePaths,
   LocalePages,
   RouteLocaleInfo,
   RuntimeI18nConfig,
   RuntimeLocale,
   RuntimeRouteContext,
+  UnlocalizedLocalePage,
 } from './i18n-runtime'
 
 const I18N_MODULES = ['@nuxtjs/i18n', 'nuxt-i18n-micro'] as const
@@ -28,10 +30,16 @@ export interface AutoI18nConfig {
   strategy: Strategies
   differentDomains?: boolean
   multiDomainLocales?: boolean
-  pages?: Record<string, Record<string, string | false>>
+  routesNameSeparator?: string
+  defaultLocaleRouteNameSuffix?: string
+  pages?: Record<string, Record<string, string | false> | UnlocalizedLocalePage | false>
 }
 
 type I18nPages = NonNullable<AutoI18nConfig['pages']>
+
+function isUnlocalizedLocalePage(page: Exclude<I18nPages[string], false | undefined>): page is UnlocalizedLocalePage {
+  return page._tag === 'unlocalized' && typeof page.path === 'string'
+}
 
 interface NuxtI18nMicroOptions extends NuxtI18nOptions {
   globalLocaleRoutes?: Record<string, I18nPages[string] | boolean>
@@ -149,24 +157,163 @@ export function normalizeLocales(nuxtI18nConfig: NuxtI18nOptions): AutoI18nConfi
   })
 }
 
-export function mapPathForI18nPages(path: string, autoI18n: AutoI18nConfig): string[] | false {
+export interface ResolvedI18nRoute {
+  name?: string
+  path: string
+  children?: ResolvedI18nRoute[]
+}
+
+interface FlatResolvedI18nRoute {
+  name?: string
+  locale?: string
+  path: string
+  isDefaultTree: boolean
+}
+
+function joinRoutePath(parentPath: string, path: string): string {
+  if (path.startsWith('/'))
+    return path
+  if (!path)
+    return parentPath || '/'
+  return `${parentPath === '/' ? '' : parentPath.replace(/\/$/, '')}/${path}`
+}
+
+function resolveLocalizedRouteName(
+  name: string | undefined,
+  autoI18n: AutoI18nConfig,
+): Pick<FlatResolvedI18nRoute, 'name' | 'locale' | 'isDefaultTree'> {
+  if (!name)
+    return { name, isDefaultTree: false }
+
+  const separator = autoI18n.routesNameSeparator || '___'
+  const defaultSuffix = autoI18n.defaultLocaleRouteNameSuffix || 'default'
+  const segments = name.split(separator)
+  const isDefaultTree = segments.at(-1) === defaultSuffix
+    && autoI18n.locales.some(locale => locale.code === segments.at(-2))
+  if (isDefaultTree)
+    segments.pop()
+  const locale = autoI18n.locales.find(locale => locale.code === segments.at(-1))?.code
+  if (locale)
+    segments.pop()
+  return {
+    name: segments.join(separator),
+    ...(locale ? { locale } : {}),
+    isDefaultTree,
+  }
+}
+
+function flattenResolvedI18nRoutes(
+  routes: readonly ResolvedI18nRoute[],
+  autoI18n: AutoI18nConfig,
+  parentPath = '',
+): FlatResolvedI18nRoute[] {
+  return routes.flatMap((route) => {
+    const path = joinRoutePath(parentPath, route.path)
+    return [
+      { ...resolveLocalizedRouteName(route.name, autoI18n), path },
+      ...flattenResolvedI18nRoutes(route.children || [], autoI18n, path),
+    ]
+  })
+}
+
+function routeKeyToName(key: string): string {
+  return key
+    .replace(/^\//, '')
+    .replace(/\/index$/, '')
+    .replace(/\[{1,2}(?:\.\.\.)?([^\]]+)\]{1,2}/g, '$1')
+    .split('/')
+    .filter(segment => !/^\([^)]+\)$/.test(segment))
+    .join('-')
+}
+
+function routeBasePath(route: FlatResolvedI18nRoute, autoI18n: AutoI18nConfig): string {
+  if (!route.locale || autoI18n.strategy === 'no_prefix')
+    return route.path
+  return resolveLocaleFromRoute(route.path, toRuntimeI18nConfig(autoI18n), { locale: route.locale }).basePath
+}
+
+/**
+ * Complete partial i18n `pages` entries from Nuxt's resolved route table.
+ *
+ * Route names are identifiers, not URL paths. The resolved route path is the
+ * only safe fallback for nested, dynamic, grouped, or custom Nuxt routes.
+ * Whole-route `false` becomes a tagged entry carrying that resolved path.
+ */
+export function materializeI18nPages(
+  autoI18n: AutoI18nConfig,
+  routes: readonly ResolvedI18nRoute[],
+): I18nPages | undefined {
+  const pages = autoI18n.pages
+  if (!pages)
+    return undefined
+
+  const resolvedRoutes = flattenResolvedI18nRoutes(routes, autoI18n)
+  return Object.fromEntries(Object.entries(pages).map(([pageName, pageLocales]) => {
+    const normalizedPageName = routeKeyToName(pageName)
+    const namedRoutes = resolvedRoutes.filter(route => route.name === pageName || route.name === normalizedPageName)
+    if (pageLocales === false) {
+      const route = namedRoutes.find(route => route.locale === autoI18n.defaultLocale)
+        || namedRoutes.find(route => !route.locale)
+        || namedRoutes[0]
+      return [pageName, route
+        ? { _tag: 'unlocalized', path: routeBasePath(route, autoI18n) }
+        : false]
+    }
+    if (isUnlocalizedLocalePage(pageLocales))
+      return [pageName, pageLocales]
+    const explicitlyMatchedRoute = resolvedRoutes.find(route => Object.values(pageLocales).some(configuredPath =>
+      typeof configuredPath === 'string' && routeBasePath(route, autoI18n) === configuredPath,
+    ))
+    const routeGroup = namedRoutes.length
+      ? namedRoutes
+      : explicitlyMatchedRoute?.name
+        ? resolvedRoutes.filter(route => route.name === explicitlyMatchedRoute.name)
+        : []
+    const defaultRoute = routeGroup.find(route => route.locale === autoI18n.defaultLocale && route.isDefaultTree)
+      || routeGroup.find(route => route.locale === autoI18n.defaultLocale)
+      || routeGroup.find(route => !route.locale)
+      || routeGroup.find(route => route.locale && pageLocales[route.locale] === undefined)
+    const originalPath = defaultRoute ? routeBasePath(defaultRoute, autoI18n) : undefined
+    const defaultPath = pageLocales[autoI18n.defaultLocale]
+    const fallbackPath = typeof defaultPath === 'string' ? defaultPath : originalPath
+
+    return [pageName, Object.fromEntries(autoI18n.locales.flatMap((locale) => {
+      const configuredPath = pageLocales[locale.code]
+      if (configuredPath !== undefined)
+        return [[locale.code, configuredPath]]
+      return fallbackPath === undefined ? [] : [[locale.code, fallbackPath]]
+    }))]
+  }))
+}
+
+export function mapPathForI18nPages(
+  path: string,
+  autoI18n: AutoI18nConfig,
+  routes: readonly ResolvedI18nRoute[] = [],
+): string[] | false {
   const pages = autoI18n.pages
   if (!pages || !Object.keys(pages).length)
     return false
 
-  const materializedPages = Object.fromEntries(
-    Object.entries(pages).map(([pageName, pageLocales]) => [
-      pageName,
-      Object.fromEntries(autoI18n.locales.map((locale) => {
-        const configuredPath = pageLocales[locale.code]
-        return [locale.code, configuredPath === undefined ? `/${pageName}` : configuredPath]
-      })),
-    ]),
-  )
+  const materializedPages = routes.length ? materializeI18nPages(autoI18n, routes) : pages
+  const resolvedRoutes = flattenResolvedI18nRoutes(routes, autoI18n)
+  const pagesForMapping = Object.fromEntries(Object.entries(materializedPages || {}).map(([pageName, pageLocales]) => {
+    if (pageLocales !== false)
+      return [pageName, pageLocales]
+    const normalizedPageName = routeKeyToName(pageName)
+    const route = resolvedRoutes.find(route => route.name === pageName || route.name === normalizedPageName)
+    if (!route)
+      return [pageName, false]
+    const originalPath = routeBasePath(route, autoI18n)
+    return [pageName, Object.fromEntries(autoI18n.locales.map(locale => [
+      locale.code,
+      locale.code === autoI18n.defaultLocale ? originalPath : false,
+    ]))]
+  }))
   const i18n = toRuntimeI18nConfig({
     ...autoI18n,
     strategy: autoI18n.strategy === 'prefix_and_default' ? 'prefix_except_default' : autoI18n.strategy,
-    pages: materializedPages,
+    pages: pagesForMapping,
   })
   const resolved = resolveLocaleAlternates(path, i18n, autoI18n.strategy === 'no_prefix'
     ? { locale: autoI18n.defaultLocale }
@@ -175,7 +322,6 @@ export function mapPathForI18nPages(path: string, autoI18n: AutoI18nConfig): str
     return false
 
   return resolved.alternates
-    .filter(alternate => autoI18n.strategy !== 'prefix_except_default' || alternate.code !== autoI18n.defaultLocale)
     .map(alternate => alternate.domain
       ? withHttps(withBase(alternate.path, alternate.domain))
       : alternate.path)
@@ -210,7 +356,7 @@ function resolveI18nPages(config: NuxtI18nOptions, isMicro: boolean): I18nPages 
 
   return Object.fromEntries(
     Object.entries(routes).filter((entry): entry is [string, I18nPages[string]] =>
-      typeof entry[1] === 'object' && entry[1] !== null && !Array.isArray(entry[1])),
+      entry[1] === false || (typeof entry[1] === 'object' && entry[1] !== null && !Array.isArray(entry[1]))),
   )
 }
 
@@ -240,6 +386,8 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
   return {
     differentDomains: nuxtI18nConfig.differentDomains,
     multiDomainLocales: nuxtI18nConfig.multiDomainLocales,
+    routesNameSeparator: nuxtI18nConfig.routesNameSeparator,
+    defaultLocaleRouteNameSuffix: nuxtI18nConfig.defaultLocaleRouteNameSuffix,
     defaultLocale: nuxtI18nConfig.defaultLocale!,
     locales: normalisedLocales,
     strategy: nuxtI18nConfig.strategy as Strategies,
@@ -250,9 +398,14 @@ export async function resolveI18nConfig(logger?: { warn: (msg: string) => void }
 /**
  * Strip a build-time i18n config down to what `./i18n-runtime` needs, dropping
  * the non-serializable `LocaleObject` extras so it can be handed to the runtime
- * through `runtimeConfig`.
+ * through `runtimeConfig`. Materialize partial and whole-route-false `pages`
+ * entries before calling this function; unresolved whole-route false entries
+ * are omitted instead of becoming fabricated runtime URLs.
  */
 export function toRuntimeI18nConfig(auto: AutoI18nConfig): RuntimeI18nConfig {
+  const pages = auto.pages && Object.fromEntries(
+    Object.entries(auto.pages).filter((entry): entry is [string, Exclude<I18nPages[string], false | undefined>] => entry[1] !== false),
+  )
   return {
     defaultLocale: auto.defaultLocale,
     strategy: auto.strategy,
@@ -261,7 +414,7 @@ export function toRuntimeI18nConfig(auto: AutoI18nConfig): RuntimeI18nConfig {
     // Translated route paths. Without these the runtime can only guess
     // alternates by adding/removing a locale prefix, which is wrong for every
     // page whose slug differs per locale.
-    ...(auto.pages && Object.keys(auto.pages).length ? { pages: auto.pages } : {}),
+    ...(pages && Object.keys(pages).length ? { pages } : {}),
     locales: auto.locales.map((l) => {
       const raw = l as typeof l & {
         name?: string

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -168,6 +168,7 @@ interface FlatResolvedI18nRoute {
   locale?: string
   path: string
   isDefaultTree: boolean
+  hasChildren: boolean
 }
 
 function joinRoutePath(parentPath: string, path: string): string {
@@ -210,7 +211,7 @@ function flattenResolvedI18nRoutes(
   return routes.flatMap((route) => {
     const path = joinRoutePath(parentPath, route.path)
     return [
-      { ...resolveLocalizedRouteName(route.name, autoI18n), path },
+      { ...resolveLocalizedRouteName(route.name, autoI18n), path, hasChildren: !!route.children?.length },
       ...flattenResolvedI18nRoutes(route.children || [], autoI18n, path),
     ]
   })
@@ -257,7 +258,11 @@ export function materializeI18nPages(
         || namedRoutes.find(route => !route.locale)
         || namedRoutes[0]
       return [pageName, route
-        ? { _tag: 'unlocalized', path: routeBasePath(route, autoI18n) }
+        ? {
+            _tag: 'unlocalized',
+            path: routeBasePath(route, autoI18n),
+            ...(route.hasChildren ? { subtree: true } : {}),
+          }
         : false]
     }
     if (isUnlocalizedLocalePage(pageLocales))

--- a/packages/shared/src/i18n.ts
+++ b/packages/shared/src/i18n.ts
@@ -216,7 +216,8 @@ function flattenResolvedI18nRoutes(
   })
 }
 
-function routeKeyToName(key: string): string {
+/** Normalize an i18n `pages` key to the corresponding resolved Nuxt route name. Build-time only. */
+export function normalizeI18nPageKey(key: string): string {
   return key
     .replace(/^\//, '')
     .replace(/\/index$/, '')
@@ -249,7 +250,7 @@ export function materializeI18nPages(
 
   const resolvedRoutes = flattenResolvedI18nRoutes(routes, autoI18n)
   return Object.fromEntries(Object.entries(pages).map(([pageName, pageLocales]) => {
-    const normalizedPageName = routeKeyToName(pageName)
+    const normalizedPageName = normalizeI18nPageKey(pageName)
     const namedRoutes = resolvedRoutes.filter(route => route.name === pageName || route.name === normalizedPageName)
     if (pageLocales === false) {
       const route = namedRoutes.find(route => route.locale === autoI18n.defaultLocale)
@@ -300,7 +301,7 @@ export function mapPathForI18nPages(
   const pagesForMapping = Object.fromEntries(Object.entries(materializedPages || {}).map(([pageName, pageLocales]) => {
     if (pageLocales !== false)
       return [pageName, pageLocales]
-    const normalizedPageName = routeKeyToName(pageName)
+    const normalizedPageName = normalizeI18nPageKey(pageName)
     const route = resolvedRoutes.find(route => route.name === pageName || route.name === normalizedPageName)
     if (!route)
       return [pageName, false]

--- a/packages/shared/test/fixtures/i18n-pages/nuxt.config.ts
+++ b/packages/shared/test/fixtures/i18n-pages/nuxt.config.ts
@@ -1,0 +1,16 @@
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/i18n'],
+  i18n: {
+    locales: ['en', 'fr'],
+    defaultLocale: 'en',
+    strategy: 'prefix_except_default',
+    customRoutes: 'config',
+    pages: {
+      'catalog-id': { fr: '/produits/[id]' },
+      'nested-about': { en: '/company' },
+      'disabled': { fr: false },
+      'unlocalized': false,
+    },
+  },
+  compatibilityDate: '2025-01-01',
+})

--- a/packages/shared/test/fixtures/i18n-pages/pages/catalog/[id].vue
+++ b/packages/shared/test/fixtures/i18n-pages/pages/catalog/[id].vue
@@ -1,0 +1,3 @@
+<template>
+  <div>catalog</div>
+</template>

--- a/packages/shared/test/fixtures/i18n-pages/pages/disabled.vue
+++ b/packages/shared/test/fixtures/i18n-pages/pages/disabled.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>disabled</div>
+</template>

--- a/packages/shared/test/fixtures/i18n-pages/pages/nested/about.vue
+++ b/packages/shared/test/fixtures/i18n-pages/pages/nested/about.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>about</div>
+</template>

--- a/packages/shared/test/fixtures/i18n-pages/pages/unlocalized.vue
+++ b/packages/shared/test/fixtures/i18n-pages/pages/unlocalized.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>unlocalized</div>
+</template>

--- a/packages/shared/test/fixtures/i18n-pages/pages/unlocalized/child.vue
+++ b/packages/shared/test/fixtures/i18n-pages/pages/unlocalized/child.vue
@@ -1,0 +1,3 @@
+<template>
+  <div>unlocalized child</div>
+</template>

--- a/packages/shared/test/integration/i18n-pages.test.ts
+++ b/packages/shared/test/integration/i18n-pages.test.ts
@@ -1,0 +1,32 @@
+import { createResolver } from '@nuxt/kit'
+import { $fetch, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const { resolve } = createResolver(import.meta.url)
+
+await setup({
+  rootDir: resolve('../fixtures/i18n-pages'),
+  server: true,
+})
+
+describe('@nuxtjs/i18n partial pages', () => {
+  it('uses the original resolved route for a missing default locale path', async () => {
+    await expect($fetch('/catalog/42')).resolves.toContain('catalog')
+    await expect($fetch('/fr/produits/42')).resolves.toContain('catalog')
+  })
+
+  it('inherits an explicit default locale path for a missing non-default locale', async () => {
+    await expect($fetch('/company')).resolves.toContain('about')
+    await expect($fetch('/fr/company')).resolves.toContain('about')
+  })
+
+  it('removes locales explicitly disabled with false', async () => {
+    await expect($fetch('/disabled')).resolves.toContain('disabled')
+    await expect($fetch('/fr/disabled')).rejects.toThrow()
+  })
+
+  it('leaves a route unlocalized when its entire pages entry is false', async () => {
+    await expect($fetch('/unlocalized')).resolves.toContain('unlocalized')
+    await expect($fetch('/fr/unlocalized')).rejects.toThrow()
+  })
+})

--- a/packages/shared/test/integration/i18n-pages.test.ts
+++ b/packages/shared/test/integration/i18n-pages.test.ts
@@ -28,5 +28,7 @@ describe('@nuxtjs/i18n partial pages', () => {
   it('leaves a route unlocalized when its entire pages entry is false', async () => {
     await expect($fetch('/unlocalized')).resolves.toContain('unlocalized')
     await expect($fetch('/fr/unlocalized')).rejects.toThrow()
+    await expect($fetch('/unlocalized/child')).resolves.toContain('child')
+    await expect($fetch('/fr/unlocalized/child')).rejects.toThrow()
   })
 })

--- a/packages/shared/test/unit/i18n-config.test.ts
+++ b/packages/shared/test/unit/i18n-config.test.ts
@@ -41,8 +41,10 @@ describe('resolveI18nConfig', () => {
     expect(config.pages).toEqual({
       checkout: { en: '/checkout', fr: '/paiement', de: '/kasse' },
       about: { en: '/about', fr: '/a-propos', de: '/ueber-uns' },
+      disabled: false,
     })
     expect(mapPathForI18nPages('/checkout', config)).toEqual([
+      '/checkout',
       '/fr/paiement',
       '/de/kasse',
     ])

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -170,6 +170,19 @@ describe('computeLocaleAlternates with translated routes', () => {
     expect(paths('/blog/hello-world', resolved)).toEqual(['/blog/hello-world', '/fr/articles/hello-world'])
   })
 
+  it('does not backtrack on malformed Vue Router patterns', () => {
+    const malformed = `/blog/:slug(${'\\('.repeat(24)}`
+    const resolved: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        'blog-slug': { en: malformed, fr: '/articles/[slug]' },
+      },
+    }
+    const startedAt = performance.now()
+    expect(paths('/blog/hello-world', resolved)).toEqual(['/blog/hello-world', '/fr/blog/hello-world'])
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  })
+
   it('carries catch-all params across locales', () => {
     expect(paths('/docs/guide/getting-started', translated))
       .toEqual(['/docs/guide/getting-started', '/fr/documentation/guide/getting-started'])

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -104,6 +104,27 @@ describe('computeLocaleAlternates', () => {
     const i18n: RuntimeI18nConfig = { ...prefixExceptDefault, pages: { about: { en: '/about', fr: '/a-propos' } } }
     expect(paths('/contact', i18n)).toEqual(['/contact', '/fr/contact'])
   })
+
+  it('does not localize a route disabled as an entire pages entry', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        unlocalized: { _tag: 'unlocalized', path: '/unlocalized' },
+      },
+    }
+    expect(resolveLocaleAlternates('/unlocalized', i18n)).toEqual({
+      _tag: 'pages',
+      alternates: [{ code: 'en', hreflang: 'en', path: '/unlocalized' }],
+    })
+    expect(resolveLocaleAlternates('/unlocalized', { ...i18n, strategy: 'prefix' })).toEqual({
+      _tag: 'pages',
+      alternates: [{ code: 'en', hreflang: 'en', path: '/unlocalized' }],
+    })
+    expect(resolveLocaleAlternates('/unlocalized', { ...i18n, strategy: 'no_prefix' })).toEqual({
+      _tag: 'pages',
+      alternates: [{ code: 'en', hreflang: 'en', path: '/unlocalized' }],
+    })
+  })
 })
 
 describe('computeLocaleAlternates with translated routes', () => {
@@ -137,6 +158,16 @@ describe('computeLocaleAlternates with translated routes', () => {
   it('carries dynamic params across locales in both directions', () => {
     expect(paths('/blog/hello-world', translated)).toEqual(['/blog/hello-world', '/fr/journal/hello-world'])
     expect(paths('/fr/journal/hello-world', translated)).toEqual(['/blog/hello-world', '/fr/journal/hello-world'])
+  })
+
+  it('matches dynamic patterns from resolved Nuxt routes', () => {
+    const resolved: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        'blog-slug': { en: '/blog/:slug()', fr: '/articles/[slug]' },
+      },
+    }
+    expect(paths('/blog/hello-world', resolved)).toEqual(['/blog/hello-world', '/fr/articles/hello-world'])
   })
 
   it('carries catch-all params across locales', () => {

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -29,6 +29,11 @@ describe('resolveLocaleFromRoute', () => {
     expect(resolveLocaleFromRoute('/fr', prefixExceptDefault)).toEqual({ locale: 'fr', basePath: '/' })
   })
 
+  it('preserves trailing slashes while stripping a locale prefix', () => {
+    expect(resolveLocaleFromRoute('/fr/about/?preview=true', prefixExceptDefault))
+      .toEqual({ locale: 'fr', basePath: '/about/?preview=true' })
+  })
+
   it('resolves prefixes without treating query or hash text as route segments', () => {
     expect(resolveLocaleFromRoute('/fr/about?preview=true#intro', prefixExceptDefault))
       .toEqual({ locale: 'fr', basePath: '/about?preview=true#intro' })
@@ -125,6 +130,47 @@ describe('computeLocaleAlternates', () => {
       alternates: [{ code: 'en', hreflang: 'en', path: '/unlocalized' }],
     })
   })
+
+  it('does not localize descendants of an unlocalized route tree', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        admin: { _tag: 'unlocalized', path: '/admin', subtree: true },
+      },
+    }
+    expect(resolveLocaleAlternates('/admin/users', i18n)).toEqual({
+      _tag: 'pages',
+      alternates: [{ code: 'en', hreflang: 'en', path: '/admin/users' }],
+    })
+  })
+
+  it('does not treat an unlocalized leading locale segment as a prefix', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        frenchLegal: { _tag: 'unlocalized', path: '/fr/legal' },
+      },
+    }
+    expect(resolveLocaleAlternates('/fr/legal', i18n)).toEqual({
+      _tag: 'pages',
+      alternates: [{ code: 'en', hreflang: 'en', path: '/fr/legal' }],
+    })
+  })
+
+  it('does not let an unlocalized entry enable unrelated no-prefix translations', () => {
+    const i18n: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      strategy: 'no_prefix',
+      pages: {
+        about: { en: '/about', fr: '/a-propos' },
+        unlocalized: { _tag: 'unlocalized', path: '/unlocalized' },
+      },
+    }
+
+    expect(paths('/about', i18n)).toEqual(['/about', '/about'])
+    expect(computeLocaleAlternates('/about', i18n, { locale: 'en' }).map(alternate => alternate.path))
+      .toEqual(['/about', '/a-propos'])
+  })
 })
 
 describe('computeLocaleAlternates with translated routes', () => {
@@ -149,6 +195,14 @@ describe('computeLocaleAlternates with translated routes', () => {
   it('translates the pathname while preserving query and hash suffixes', () => {
     expect(paths('/about?preview=true#intro', translated))
       .toEqual(['/about?preview=true#intro', '/fr/a-propos?preview=true#intro'])
+  })
+
+  it('preserves trailing slashes from resolved route patterns', () => {
+    const trailingSlash: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: { about: { en: '/about/', fr: '/a-propos/' } },
+    }
+    expect(paths('/about/', trailingSlash)).toEqual(['/about/', '/fr/a-propos/'])
   })
 
   it('resolves back from a translated route to the default one', () => {
@@ -180,6 +234,22 @@ describe('computeLocaleAlternates with translated routes', () => {
     }
     const startedAt = performance.now()
     expect(paths('/blog/hello-world', resolved)).toEqual(['/blog/hello-world', '/fr/blog/hello-world'])
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  })
+
+  it('bounds backtracking across adjacent embedded params', () => {
+    const params = Array.from({ length: 9 }, (_, index) => `:p${index}()`).join('')
+    const resolved: RuntimeI18nConfig = {
+      ...prefixExceptDefault,
+      pages: {
+        adversarial: { en: `/${params}Z`, fr: '/articles/[p0]' },
+      },
+    }
+    const startedAt = performance.now()
+    expect(paths(`/${'a'.repeat(25)}`, resolved)).toEqual([
+      `/${'a'.repeat(25)}`,
+      `/fr/${'a'.repeat(25)}`,
+    ])
     expect(performance.now() - startedAt).toBeLessThan(500)
   })
 

--- a/packages/shared/test/unit/i18n.test.ts
+++ b/packages/shared/test/unit/i18n.test.ts
@@ -493,6 +493,19 @@ describe('materializeI18nPages', () => {
     expect(mapPathForI18nPages('/about', config, routes)).toEqual(['/about'])
   })
 
+  it('marks an entirely unlocalized route tree', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { admin: false },
+    }), [{
+      name: 'admin',
+      path: '/admin',
+      children: [{ name: 'admin-users', path: 'users' }],
+    }])).toEqual({
+      admin: { _tag: 'unlocalized', path: '/admin', subtree: true },
+    })
+  })
+
   it('uses the resolved route for locales omitted beside a disabled default', () => {
     expect(materializeI18nPages(makeAutoI18n({
       locales: [makeLocale('en'), makeLocale('fr')],

--- a/packages/shared/test/unit/i18n.test.ts
+++ b/packages/shared/test/unit/i18n.test.ts
@@ -7,6 +7,7 @@ import {
   mapPathForI18nPages,
   materializeI18nPages,
   mergeOnKey,
+  normalizeI18nPageKey,
   normalizeLocales,
   splitPathForI18nLocales,
 } from '../../src/i18n'
@@ -553,5 +554,17 @@ describe('materializeI18nPages', () => {
     }), [])).toEqual({
       missing: { fr: '/manquant' },
     })
+  })
+})
+
+describe('normalizeI18nPageKey', () => {
+  it.each([
+    ['services/development/index', 'services-development'],
+    ['/blog/[slug]', 'blog-slug'],
+    ['docs/[...slug]', 'docs-slug'],
+    ['docs/[[...slug]]', 'docs-slug'],
+    ['(marketing)/about', 'about'],
+  ])('normalizes %s to the resolved route name %s', (key, expected) => {
+    expect(normalizeI18nPageKey(key)).toBe(expected)
   })
 })

--- a/packages/shared/test/unit/i18n.test.ts
+++ b/packages/shared/test/unit/i18n.test.ts
@@ -5,6 +5,7 @@ import {
   generatePathForI18nPages,
   isCompactLocaleRoute,
   mapPathForI18nPages,
+  materializeI18nPages,
   mergeOnKey,
   normalizeLocales,
   splitPathForI18nLocales,
@@ -326,6 +327,14 @@ describe('mapPathForI18nPages', () => {
     expect(mapPathForI18nPages('/about', config)).toBe(false)
   })
 
+  it('does not invent a path for an unmaterialized partial entry', () => {
+    const config = makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: { fr: '/a-propos' } },
+    })
+    expect(mapPathForI18nPages('/about', config)).toBe(false)
+  })
+
   it('maps a page with custom locale paths', () => {
     const config = makeAutoI18n({
       pages: {
@@ -335,8 +344,9 @@ describe('mapPathForI18nPages', () => {
         },
       },
     })
-    const result = mapPathForI18nPages('/about', config)
+    const result = mapPathForI18nPages('/about', config, [{ name: 'about___en', path: '/about' }])
     expect(result).toBeInstanceOf(Array)
+    expect(result).toContain('/about')
     expect(result).toContain('/fr/a-propos')
     expect(result).toContain('/es/acerca')
   })
@@ -350,7 +360,7 @@ describe('mapPathForI18nPages', () => {
         },
       },
     })
-    const result = mapPathForI18nPages('/about', config)
+    const result = mapPathForI18nPages('/about', config, [{ name: 'about___en', path: '/about' }])
     expect(result).toBeInstanceOf(Array)
     const paths = result as string[]
     expect(paths.some(p => p.includes('/fr'))).toBe(false)
@@ -380,7 +390,7 @@ describe('mapPathForI18nPages', () => {
         },
       },
     })
-    const result = mapPathForI18nPages('/about/', config)
+    const result = mapPathForI18nPages('/about/', config, [{ name: 'about___en', path: '/about' }])
     expect(result).toBeInstanceOf(Array)
   })
 
@@ -394,7 +404,7 @@ describe('mapPathForI18nPages', () => {
         },
       },
     })
-    expect(mapPathForI18nPages('/posts/hello', config)).toEqual(['/fr/articles/hello'])
+    expect(mapPathForI18nPages('/posts/hello', config)).toEqual(['/posts/hello', '/fr/articles/hello'])
   })
 
   it('preserves translated paths under no_prefix', () => {
@@ -409,5 +419,139 @@ describe('mapPathForI18nPages', () => {
       },
     })
     expect(mapPathForI18nPages('/about', config)).toEqual(['/about', '/a-propos', '/acerca'])
+  })
+})
+
+describe('materializeI18nPages', () => {
+  it('uses the configured default path for omitted locales', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: { en: '/about-us' } },
+    }), [
+      { name: 'about___en', path: '/about-us' },
+      { name: 'about___fr', path: '/fr/about-us' },
+    ])).toEqual({
+      about: { en: '/about-us', fr: '/about-us' },
+    })
+  })
+
+  it('uses the resolved nested route path when the default locale is omitted', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { 'services-development': { fr: '/offres/developpement' } },
+    }), [
+      {
+        name: 'services___en',
+        path: '/services',
+        children: [
+          { name: 'services-development___en', path: 'development' },
+        ],
+      },
+    ])).toEqual({
+      'services-development': {
+        en: '/services/development',
+        fr: '/offres/developpement',
+      },
+    })
+  })
+
+  it('uses the resolved dynamic route pattern when the default locale is omitted', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { 'blog-slug': { fr: '/articles/[slug]' } },
+    }), [
+      { name: 'blog-slug___en', path: '/blog/:slug()' },
+    ])).toEqual({
+      'blog-slug': {
+        en: '/blog/:slug()',
+        fr: '/articles/[slug]',
+      },
+    })
+  })
+
+  it('preserves disabled locale routes', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: { fr: false } },
+    }), [
+      { name: 'about___en', path: '/about' },
+    ])).toEqual({
+      about: { en: '/about', fr: false },
+    })
+  })
+
+  it('preserves an entirely unlocalized route', () => {
+    const config = makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: false },
+    })
+    const routes = [{ name: 'about', path: '/about' }]
+    expect(materializeI18nPages(config, routes)).toEqual({
+      about: { _tag: 'unlocalized', path: '/about' },
+    })
+    expect(mapPathForI18nPages('/about', config, routes)).toEqual(['/about'])
+  })
+
+  it('uses the resolved route for locales omitted beside a disabled default', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: { en: false } },
+    }), [{ name: 'about___fr', path: '/fr/about' }])).toEqual({
+      about: { en: false, fr: '/about' },
+    })
+  })
+
+  it('does not reuse an explicit translation when the original route is unavailable', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr'), makeLocale('de')],
+      pages: { about: { en: false, fr: '/a-propos' } },
+    }), [{ name: 'about___fr', path: '/fr/a-propos' }])).toEqual({
+      about: { en: false, fr: '/a-propos' },
+    })
+  })
+
+  it.each([
+    ['prefix_except_default', '/about', 'about___en'],
+    ['prefix', '/en/about', 'about___en'],
+    ['prefix_and_default', '/about', 'about___en___default'],
+    ['no_prefix', '/about', 'about___en'],
+  ] as const)('strips the generated prefix under %s', (strategy, path, name) => {
+    expect(materializeI18nPages(makeAutoI18n({
+      strategy,
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { about: { fr: '/a-propos' } },
+    }), [{ name, path }])).toEqual({
+      about: { en: '/about', fr: '/a-propos' },
+    })
+  })
+
+  it('uses custom localized route name separators and default suffixes', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      strategy: 'prefix_and_default',
+      locales: [makeLocale('en'), makeLocale('fr')],
+      routesNameSeparator: '--',
+      defaultLocaleRouteNameSuffix: 'base',
+      pages: { about: { fr: '/a-propos' } },
+    }), [{ name: 'about--en--base', path: '/about' }])).toEqual({
+      about: { en: '/about', fr: '/a-propos' },
+    })
+  })
+
+  it('matches legacy path keys to resolved route names', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { 'services/development/index': { fr: '/offres/developpement' } },
+    }), [{ name: 'services-development___en', path: '/services/development' }])).toEqual({
+      'services/development/index': { en: '/services/development', fr: '/offres/developpement' },
+    })
+  })
+
+  it('never fabricates a path for an unresolved route', () => {
+    expect(materializeI18nPages(makeAutoI18n({
+      locales: [makeLocale('en'), makeLocale('fr')],
+      pages: { missing: { fr: '/manquant' } },
+    }), [])).toEqual({
+      missing: { fr: '/manquant' },
+    })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [x] ⚠️ Breaking change

### 📚 Description

Partial `@nuxtjs/i18n` pages entries used route names as fallback URLs. That fabricated paths for nested and dynamic routes and dropped default filter paths.

`materializeI18nPages` now reads resolved Nuxt routes, preserves whole-route `false` as a tagged unlocalized entry, and handles Nuxt and Vue Router parameter forms. Review fixes cover unlocalized child trees, raw paths beginning with a locale segment, `no_prefix` isolation, trailing slashes, and bounded route matcher backtracking.

### ⚠️ Breaking changes

`AutoI18nConfig.pages` can now contain whole-entry `false` and `UnlocalizedLocalePage`. Consumers that index raw page entries must discriminate those states first.

### 📝 Migration

Capture resolved Nuxt pages, call `materializeI18nPages(autoI18n, pages)`, then pass the result to `toRuntimeI18nConfig`. The shared runtime functions handle the tagged unlocalized state.

Preview-package checks passed against sitemap, robots, and ai-ready: all three typechecks and 585 unit tests pass. Their follow-up releases still need to adopt route materialization so partial and whole-route-false entries affect module output.