### PR TITLE
fix(shared): resolve canonical locale domains

### DIFF
--- a/packages/shared/src/i18n-runtime.ts
+++ b/packages/shared/src/i18n-runtime.ts
@@ -88,8 +88,19 @@ function resolveLocaleFromHost(host: string | undefined, i18n: RuntimeI18nConfig
   return matches.length === 1 ? matches[0] : matches.find(locale => locale.code === i18n.defaultLocale)
 }
 
-function resolveLocaleDomain(locale: RuntimeLocale): string | undefined {
-  return locale.defaultForDomains?.[0] || locale.domain || locale.domains?.[0]
+function firstLocaleDomain(locale: RuntimeLocale | undefined): string | undefined {
+  return locale?.defaultForDomains?.[0] || locale?.domain || locale?.domains?.[0]
+}
+
+/**
+ * Resolve the canonical domain for a locale. Domainless locales are served on
+ * every domain, so their stable canonical is the default locale's domain.
+ */
+export function resolveCanonicalLocaleDomain(
+  locale: RuntimeLocale | undefined,
+  defaultLocale?: RuntimeLocale,
+): string | undefined {
+  return firstLocaleDomain(locale) || firstLocaleDomain(defaultLocale)
 }
 
 function splitRouteSuffix(route: string): { pathname: string, suffix: string } {
@@ -361,6 +372,7 @@ function alternatesForEntry(
   // Without that pattern the original route is unknowable from i18n pages.
   const untranslated = localePaths[i18n.defaultLocale]
   const alternates: LocaleAlternate[] = []
+  const defaultLocale = i18n.locales.find(locale => locale.code === i18n.defaultLocale)
 
   for (const l of i18n.locales) {
     const pattern = localePaths[l.code] ?? untranslated
@@ -372,7 +384,7 @@ function alternatesForEntry(
     const path = fillPagePattern(pattern, params)
     if (path === null)
       continue
-    const domain = resolveLocaleDomain(l)
+    const domain = resolveCanonicalLocaleDomain(l, defaultLocale)
     alternates.push({
       code: l.code,
       hreflang: l.hreflang || l.code,
@@ -447,10 +459,11 @@ export function resolveLocaleAlternates(
     }
   }
 
+  const defaultLocale = i18n.locales.find(locale => locale.code === i18n.defaultLocale)
   return {
     _tag: 'strategy',
     alternates: i18n.locales.map((l) => {
-      const domain = resolveLocaleDomain(l)
+      const domain = resolveCanonicalLocaleDomain(l, defaultLocale)
       return {
         code: l.code,
         hreflang: l.hreflang || l.code,

--- a/packages/shared/test/unit/i18n-runtime.test.ts
+++ b/packages/shared/test/unit/i18n-runtime.test.ts
@@ -2,7 +2,7 @@ import type { AutoI18nConfig } from '../../src/i18n'
 import type { RuntimeI18nConfig } from '../../src/i18n-runtime'
 import { describe, expect, it } from 'vitest'
 import { toRuntimeI18nConfig } from '../../src/i18n'
-import { computeLocaleAlternates, localePath, resolveLocaleAlternates, resolveLocaleFromRoute } from '../../src/i18n-runtime'
+import { computeLocaleAlternates, localePath, resolveCanonicalLocaleDomain, resolveLocaleAlternates, resolveLocaleFromRoute } from '../../src/i18n-runtime'
 
 const en = { code: 'en', hreflang: 'en' }
 const fr = { code: 'fr', hreflang: 'fr-FR' }
@@ -15,6 +15,24 @@ const prefixExceptDefault: RuntimeI18nConfig = {
 }
 
 const paths = (route: string, i18n: RuntimeI18nConfig) => computeLocaleAlternates(route, i18n).map(a => a.path)
+
+describe('resolveCanonicalLocaleDomain', () => {
+  it('prefers the configured canonical domain', () => {
+    expect(resolveCanonicalLocaleDomain({
+      ...en,
+      domain: 'legacy.example.com',
+      domains: ['alias.example.com'],
+      defaultForDomains: ['canonical.example.com'],
+    })).toBe('canonical.example.com')
+  })
+
+  it('falls back to the default locale domain for a domainless locale', () => {
+    expect(resolveCanonicalLocaleDomain(fr, {
+      ...en,
+      domain: 'example.com',
+    })).toBe('example.com')
+  })
+})
 
 describe('resolveLocaleFromRoute', () => {
   it('strips the prefix to find the locale', () => {


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [ ] 📖 Documentation
- [x] 🐞 Bug fix
- [ ] 👌 Enhancement
- [ ] ✨ New feature
- [ ] 🧹 Chore
- [ ] ⚠️ Breaking change

### 📚 Description

Expose one runtime-safe canonical locale domain resolver for SEO modules. It prefers `defaultForDomains`, falls back through the locale domain fields, and uses the default locale domain when a locale is served across every domain.

Nuxt Site Config can now consume the same domain decision used by shared alternate URL generation instead of relying on `@nuxtjs/i18n`'s request-scoped `baseUrl`.