### PR TITLE
fix(shared): avoid `__dirname` in generated devtools nuxt config

### DIFF
--- a/packages/shared/src/devtools.ts
+++ b/packages/shared/src/devtools.ts
@@ -279,14 +279,13 @@ function generateAndBuild(cacheDir: string, rootDir: string, installed: SeoDevto
   const routes = ['/', ...installed.flatMap(m => deriveRoutes(m.layerDir, m.slug))]
   const extendsList = [resolveBaseLayer(installed), ...installed.map(m => m.layerDir)]
   mkdirSync(join(cacheDir, 'pages'), { recursive: true })
-  writeFileSync(join(cacheDir, 'nuxt.config.ts'), `import { resolve } from 'pathe'
-export default defineNuxtConfig({
+  writeFileSync(join(cacheDir, 'nuxt.config.ts'), `export default defineNuxtConfig({
   extends: ${JSON.stringify(extendsList, null, 2)},
   ssr: false,
   robots: false,
   content: false,
   sitemap: false,
-  nitro: { prerender: { routes: ${JSON.stringify(routes)} }, output: { publicDir: resolve(__dirname, './dist/devtools') } },
+  nitro: { prerender: { routes: ${JSON.stringify(routes)} }, output: { publicDir: ${JSON.stringify(join(cacheDir, 'dist/devtools'))} } },
   app: { baseURL: '${UNIFIED_CLIENT_ROUTE}' },
   compatibilityDate: '2026-03-13',
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

cjs globals have been polyfilled by jiti for a while but these aren't guaranteed to exist in the future
