### PR TITLE
chore: adopt eslint-plugin-harlanzw base config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,8 +7,7 @@ export default antfu(
     vue: true,
   },
   ...harlanzw({
-    // base only ignores a root-level `playground/`, and this repo has one per package
-    base: { ignores: ['**/playground/**'] },
+    base: true,
     link: true,
     nuxt: true,
     vue: true,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,29 +5,17 @@ export default antfu(
   {
     type: 'lib',
     vue: true,
-    ignores: [
-      'CLAUDE.md',
-      'test/fixtures/**',
-      'playground/**',
-      '**/test/fixtures/**',
-      '**/playground/**',
-      '.claude',
-    ],
-    rules: {
-      'node/prefer-global/buffer': 'off',
-    },
   },
-  ...harlanzw({ link: true, nuxt: true, vue: true }),
+  ...harlanzw({
+    // base only ignores a root-level `playground/`, and this repo has one per package
+    base: { ignores: ['**/playground/**'] },
+    link: true,
+    nuxt: true,
+    vue: true,
+  }),
   {
     rules: {
       'harlanzw/prompt-mixed-conventions': 'off',
-    },
-  },
-  {
-    files: ['examples/*/package.json'],
-    rules: {
-      'pnpm/json-enforce-catalog': 'off',
-      'pnpm/json-prefer-workspace-settings': 'off',
     },
   },
 )

--- a/packages/devtools-layer/composables/checklist.ts
+++ b/packages/devtools-layer/composables/checklist.ts
@@ -482,7 +482,6 @@ export async function evaluate(): Promise<void> {
   loading.value = false
 }
 
-// eslint-disable-next-line ts/explicit-function-return-type
 export function getSetupChecklist() {
   return {
     results,

--- a/packages/shared/src/content.ts
+++ b/packages/shared/src/content.ts
@@ -79,7 +79,6 @@ export interface DefineContentSchemaConfig<TSchema = any, TDefineOptions extends
  *
  * export { defineSchema as defineRobotsSchema, asCollection as asRobotsCollection, schema }
  */
-// eslint-disable-next-line ts/explicit-function-return-type
 export function createContentSchemaFactory<TSchema, TDefineOptions extends ContentSchemaOptions = ContentSchemaOptions>(
   config: DefineContentSchemaConfig<TSchema, TDefineOptions>,
   defaultZ: Zod,

--- a/packages/shared/src/pro.ts
+++ b/packages/shared/src/pro.ts
@@ -11,9 +11,7 @@ export function hookNuxtSeoProDataUpload(): void {
   const isBuild = !nuxt.options.dev && !nuxt.options._prepare
   // @ts-expect-error untyped
   if (isBuild && !nuxt._isNuxtSeoProUploading) {
-    // eslint-disable-next-line node/prefer-global/process
     const license = nuxt.options.runtimeConfig.seoProKey || process.env.NUXT_SEO_PRO_KEY
-    // eslint-disable-next-line node/prefer-global/process
     if (isTest || process.env.VITEST || !license) {
       return
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.19.0
-      version: 0.19.0
+      specifier: ^0.19.1
+      version: 0.19.1
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -215,7 +215,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       lint-staged:
         specifier: 'catalog:'
         version: 17.3.0
@@ -5466,8 +5466,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.19.0:
-    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
+  eslint-plugin-harlanzw@0.19.1:
+    resolution: {integrity: sha512-2ehKTbwNpmM9XCHjT1I+DS2QdP/GM/GSX6K4kKPvCW0w39RWtr0/AD9AMu1dmbkm4JcbIYNKFW8Y+IRe6WSW4w==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -15949,7 +15949,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.17.1
-      version: 0.17.1
+      specifier: ^0.18.0
+      version: 0.18.0
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -215,7 +215,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       lint-staged:
         specifier: 'catalog:'
         version: 17.3.0
@@ -5466,8 +5466,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.17.1:
-    resolution: {integrity: sha512-JTqWyTYDdMGvo5RDQ1ugq8Y2hGhcSL432WZX3ls52Ie5e+L2MncacI5OrArWB6/8pO7pK3qdm+hgiaFVXmmHxw==}
+  eslint-plugin-harlanzw@0.18.0:
+    resolution: {integrity: sha512-SX83tlR7KMCeovEWsTqMY4uUCCcaFk7zM15GuEcBWSzteqYv4Fq9ojDxlLTieO4A+5uj1O+uL6UzHzWgsBcpIw==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -15949,7 +15949,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.17.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.8.1
     eslint-plugin-harlanzw:
-      specifier: ^0.18.0
-      version: 0.18.0
+      specifier: ^0.19.0
+      version: 0.19.0
     execa:
       specifier: ^10.0.1
       version: 10.0.1
@@ -215,7 +215,7 @@ importers:
         version: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-harlanzw:
         specifier: 'catalog:'
-        version: 0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
+        version: 0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
       lint-staged:
         specifier: 'catalog:'
         version: 17.3.0
@@ -5466,8 +5466,8 @@ packages:
     peerDependencies:
       eslint: '>=8'
 
-  eslint-plugin-harlanzw@0.18.0:
-    resolution: {integrity: sha512-SX83tlR7KMCeovEWsTqMY4uUCCcaFk7zM15GuEcBWSzteqYv4Fq9ojDxlLTieO4A+5uj1O+uL6UzHzWgsBcpIw==}
+  eslint-plugin-harlanzw@0.19.0:
+    resolution: {integrity: sha512-Y/fxnaU7J3P9J45RQnlnRo2WEgCXlP9xZD+qfE9UwIykIi4uHo/TeH5qJMYLN8ghQCqyF5alasxHRlAU6nHh7g==}
     peerDependencies:
       eslint: '>=9.0.0'
 
@@ -15949,7 +15949,7 @@ snapshots:
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)
       eslint-compat-utils: 0.5.1(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))
 
-  eslint-plugin-harlanzw@0.18.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
+  eslint-plugin-harlanzw@0.19.0(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2)):
     dependencies:
       '@eslint/plugin-kit': 0.7.2
       eslint: 10.8.1(jiti@2.7.0)(supports-color@10.2.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ minimumReleaseAgeExclude:
   - unhead@3.2.1
   - '@unhead/vue@3.2.1'
   - '@mdream/rust-wasm32-wasi@1.5.12'
-  - eslint-plugin-harlanzw@0.18.0
+  - eslint-plugin-harlanzw@0.19.0
 # pnpm 11 reads these from pnpm-workspace.yaml, not .npmrc.
 # @nuxtjs/i18n resolves its private @intlify/* + vue-i18n deps via @nuxt/kit's
 # resolveModule, which only searches root node_modules, so hoist just those
@@ -112,7 +112,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.18.0
+  eslint-plugin-harlanzw: ^0.19.0
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,6 +60,7 @@ minimumReleaseAgeExclude:
   - unhead@3.2.1
   - '@unhead/vue@3.2.1'
   - '@mdream/rust-wasm32-wasi@1.5.12'
+  - eslint-plugin-harlanzw@0.18.0
 # pnpm 11 reads these from pnpm-workspace.yaml, not .npmrc.
 # @nuxtjs/i18n resolves its private @intlify/* + vue-i18n deps via @nuxt/kit's
 # resolveModule, which only searches root node_modules, so hoist just those
@@ -111,7 +112,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.17.1
+  eslint-plugin-harlanzw: ^0.18.0
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,7 @@ minimumReleaseAgeExclude:
   - unhead@3.2.1
   - '@unhead/vue@3.2.1'
   - '@mdream/rust-wasm32-wasi@1.5.12'
-  - eslint-plugin-harlanzw@0.19.0
+  - eslint-plugin-harlanzw@0.19.1
 # pnpm 11 reads these from pnpm-workspace.yaml, not .npmrc.
 # @nuxtjs/i18n resolves its private @intlify/* + vue-i18n deps via @nuxt/kit's
 # resolveModule, which only searches root node_modules, so hoist just those
@@ -112,7 +112,7 @@ catalog:
   consola: ^3.4.2
   defu: ^6.1.7
   eslint: ^10.8.1
-  eslint-plugin-harlanzw: ^0.19.0
+  eslint-plugin-harlanzw: ^0.19.1
   execa: ^10.0.1
   h3: ^1.15.11
   happy-dom: ^20.11.2


### PR DESCRIPTION
### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

The override blocks in `eslint.config.mjs` were copy-pasted across all eight nuxt-seo module repos. `eslint-plugin-harlanzw` ships them as `base()`, so they can be deleted here. 33 lines to 19.

```js
export default antfu(
  { type: 'lib', vue: true },
  ...harlanzw({
    base: true,
    link: true,
    nuxt: true,
    vue: true,
  }),
  { rules: { 'harlanzw/prompt-mixed-conventions': 'off' } },
)
```

The hand-written ignore list (`CLAUDE.md`, `.claude`, fixtures, playgrounds) and the `node/prefer-global/buffer` override are all in the shared ignore/rule blocks now. Only the `harlanzw/prompt-mixed-conventions` disable is genuinely specific to this repo, so it stays inline.

Base turns off a few rules this repo was still enforcing: `ts/no-use-before-define`, `ts/explicit-function-return-type` (via `type: 'lib'`), `node/prefer-global/process`, and `pnpm/json-valid-catalog` on example manifests. Test files also lose `no-console` and `ts/no-unsafe-function-type`. That made four inline `eslint-disable-next-line` comments dead, so they are gone too.

I diffed `eslint --print-config` for a module source file, a test file, and `examples/basic/package.json` against `origin/main`. Every resolved severity change is one of those deliberate relaxations, plus two new rules arriving at `warn`: `harlanzw/prefer-satisfies` and `harlanzw/nuxt-no-redundant-component-imports`.

### 📝 Additional context

This is pinned to 0.19.2 rather than 0.18.0, which resolves both of the open questions from the first pass.

**Recursive ignore globs.** 0.18.0 base only ignored a root-level `playground/`, so the call site needed `base: { ignores: ['**/playground/**'] }`. 0.19.2 makes the base globs recursive (`**/playground/**`, `**/.data/**`, and the agent globs likewise), so that workaround is gone. I ran the full lint with and without it on an identical tree: 177 files and the same 12 messages either way, so the resolved file set does not move.

**Agent files are linted now.** In 0.18.0 the agent globs (`CLAUDE.md`, `AGENTS.md`, `.claude/**`, `.cursor/**`) always sat in base's global `ignores` block. A flat-config global ignore beats any later `files`-scoped config, so the prompt rules could never reach them. 0.19.2 adds an `agentFiles` option and `harlanzw()` passes `'lint'` whenever prompt detection is on. This repo has `CLAUDE.md` and `.claude/`, so prompt rules now apply to `CLAUDE.md`.

That adds one file to the lint run and one finding:

```
CLAUDE.md:1:1  warning  harlanzw/prompt-missing-examples
  Output format specified but no examples provided.
  Adding a few-shot example can clarify expected structure.
```

I kept agent files in the lint run rather than opting back out with `agentFiles: 'ignore'`. This repo already lints `SKILL.md` through the same prompt config, which is why the `prompt-mixed-conventions` disable exists, so covering `CLAUDE.md` matches what the repo already asked for. The finding itself is left alone: the text it flags lives inside the `<!-- skilld -->` managed block, which is regenerated, so an example added there would not survive.

**File set and messages against `origin/main`,** measured on an identical source tree so only the config and the version move:

| | `origin/main` | this branch |
|---|---|---|
| files linted | 176 | 177 (`+CLAUDE.md`) |
| errors | 0 | 0 |
| warnings | 0 | 8 |

The 8 warnings are 7 `harlanzw/prefer-satisfies` (`Record<string, string>` annotations in devtools-layer and `shared/src/kit.ts`) and the one `prompt-missing-examples` above. Both are new rule coverage, not regressions, and `pnpm lint` still exits 0. `prefer-satisfies` has nothing to do with base, so it is worth a pass on its own.

`pnpm lint` and `pnpm typecheck` both pass. `nuxtseo-shared` unit tests pass, 191 of 191.

This repo is the pilot for the family, so sitemap, robots, nuxt-schema-org, nuxt-seo-utils, nuxt-site-config, nuxt-link-checker and og-image can follow the same shape.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).



