### PR TITLE
fix(ci): retry transient failures in the reusable workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,23 +13,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Set up pnpm and Node.js
-        uses: pnpm/setup@v2
-        with:
-          runtime: node@lts
-          cache: true
-          install: false
-
-      - run: pnpm install --frozen-lockfile --trust-lockfile
-      - run: pnpm dev:prepare
-
-      - name: Build
-        run: pnpm run build
-
-      - name: Publish
-        run: pnpm dlx pkg-pr-new publish --pnpm ./packages/nuxt-seo ./packages/shared
+    uses: ./.github/workflows/reusable-nightly.yml
+    with:
+      runner: ubuntu-latest
+      publish-packages: ./packages/nuxt-seo ./packages/shared

--- a/.github/workflows/performance-comment.yml
+++ b/.github/workflows/performance-comment.yml
@@ -118,11 +118,67 @@ jobs:
           fi
           sed 's/@/@<!-- -->/g' "$report" > "$COMMENT_PATH"
 
+      # Replaces marocchino/sticky-pull-request-comment. That action fails the
+      # check on a single transient GitHub API error. The marker format is kept
+      # identical so existing sticky comments are still updated in place.
       - name: Post comment on pull request
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/performance-comment.md
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+          STICKY_HEADER: SSR Performance Analysis
         with:
-          GITHUB_TOKEN: ${{ github.token }}
-          header: SSR Performance Analysis
-          number: ${{ steps.pull-request.outputs.number }}
-          path: ${{ runner.temp }}/performance-comment.md
-          skip_unchanged: true
+          script: |
+            const { readFileSync } = require('node:fs')
+
+            // The GitHub API returns transient 5xx / 429 / network errors.
+            // Retry those with backoff. Any other error fails the step at once.
+            async function withRetry(label, fn) {
+              for (let attempt = 1; ; attempt++) {
+                try {
+                  return await fn()
+                }
+                catch (error) {
+                  const status = error.status
+                  const transient = status === undefined || status === 429 || status >= 500
+                  if (!transient || attempt >= 5)
+                    throw error
+                  const wait = Math.min(2000 * 2 ** (attempt - 1), 30000)
+                  core.warning(`${label} failed with a transient error (${error.message}). Retrying in ${wait}ms.`)
+                  await new Promise(resolve => setTimeout(resolve, wait))
+                }
+              }
+            }
+
+            const { owner, repo } = context.repo
+            const issueNumber = Number(process.env.PR_NUMBER)
+            const marker = `<!-- Sticky Pull Request Comment${process.env.STICKY_HEADER} -->`
+            const body = `${readFileSync(process.env.COMMENT_PATH, 'utf8')}\n${marker}`
+
+            const comments = await withRetry('issues.listComments', () =>
+              github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              }),
+            )
+            const existing = comments.find(comment => comment.body?.includes(marker))
+
+            if (!existing) {
+              await withRetry('issues.createComment', () =>
+                github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body }),
+              )
+              core.info(`Created the performance comment on pull request #${issueNumber}`)
+              return
+            }
+
+            if (existing.body === body) {
+              core.info('The performance comment is unchanged. Skipping the update.')
+              return
+            }
+
+            await withRetry('issues.updateComment', () =>
+              github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body }),
+            )
+            core.info(`Updated the performance comment on pull request #${issueNumber}`)

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -33,6 +33,12 @@ on:
         type: boolean
         default: true
 
+env:
+  # Retry registry requests instead of failing the job on a transient 5xx.
+  NPM_CONFIG_FETCH_RETRIES: '5'
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '20000'
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+
 jobs:
   lint:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/reusable-nightly.yml
+++ b/.github/workflows/reusable-nightly.yml
@@ -28,6 +28,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Retry registry requests instead of failing the job on a transient 5xx.
+  NPM_CONFIG_FETCH_RETRIES: '5'
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '20000'
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+
 jobs:
   build:
     runs-on: ${{ inputs.runner }}
@@ -48,5 +54,24 @@ jobs:
 
       - run: pnpm build
 
+      # pkg.pr.new is a third party service. It returns transient 5xx errors
+      # that survive the publisher's own retries. Retry here so an outage does
+      # not fail the default branch build.
       - name: Publish
-        run: pnpm dlx pkg-pr-new publish --pnpm ${{ inputs.publish-packages }}
+        env:
+          PUBLISH_PACKAGES: ${{ inputs.publish-packages }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            echo "::group::pkg-pr-new publish attempt $attempt"
+            if pnpm dlx pkg-pr-new publish --pnpm $PUBLISH_PACKAGES; then
+              echo "::endgroup::"
+              exit 0
+            fi
+            echo "::endgroup::"
+            echo "::warning::pkg-pr-new publish failed on attempt $attempt"
+            if [ "$attempt" -lt 5 ]; then
+              sleep 30
+            fi
+          done
+          echo "::error::pkg-pr-new publish failed after 5 attempts"
+          exit 1

--- a/.github/workflows/reusable-package-size-comment.yml
+++ b/.github/workflows/reusable-package-size-comment.yml
@@ -17,6 +17,25 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            // The GitHub API returns transient 5xx / 429 / network errors.
+            // Retry those with backoff. Any other error fails the step at once.
+            async function withRetry(label, fn) {
+              for (let attempt = 1; ; attempt++) {
+                try {
+                  return await fn()
+                }
+                catch (error) {
+                  const status = error.status
+                  const transient = status === undefined || status === 429 || status >= 500
+                  if (!transient || attempt >= 5)
+                    throw error
+                  const wait = Math.min(2000 * 2 ** (attempt - 1), 30000)
+                  core.warning(`${label} failed with a transient error (${error.message}). Retrying in ${wait}ms.`)
+                  await new Promise(resolve => setTimeout(resolve, wait))
+                }
+              }
+            }
+
             const run = context.payload.workflow_run
             const headOwner = run.head_repository?.owner?.login
             if (!headOwner || !run.head_branch) {
@@ -24,13 +43,13 @@ jobs:
               return
             }
 
-            const { data: pullRequests } = await github.rest.pulls.list({
+            const pullRequests = await withRetry('pulls.list', () => github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open',
               head: `${headOwner}:${run.head_branch}`,
               per_page: 100,
-            })
+            }))
             const expectedHeadRepository = run.head_repository.full_name
             const expectedBaseRepository = `${context.repo.owner}/${context.repo.repo}`
             const matches = pullRequests.filter(pullRequest =>
@@ -107,11 +126,67 @@ jobs:
           fi
           sed 's/@/@<!-- -->/g' "$report" > "$COMMENT_PATH"
 
+      # Replaces marocchino/sticky-pull-request-comment. That action fails the
+      # check on a single transient GitHub API error. The marker format is kept
+      # identical so existing sticky comments are still updated in place.
       - name: Post comment on pull request
-        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          COMMENT_PATH: ${{ runner.temp }}/package-size-comment.md
+          PR_NUMBER: ${{ steps.pull-request.outputs.number }}
+          STICKY_HEADER: Package Size Analysis
         with:
-          GITHUB_TOKEN: ${{ github.token }}
-          header: Package Size Analysis
-          number: ${{ steps.pull-request.outputs.number }}
-          path: ${{ runner.temp }}/package-size-comment.md
-          skip_unchanged: true
+          script: |
+            const { readFileSync } = require('node:fs')
+
+            // The GitHub API returns transient 5xx / 429 / network errors.
+            // Retry those with backoff. Any other error fails the step at once.
+            async function withRetry(label, fn) {
+              for (let attempt = 1; ; attempt++) {
+                try {
+                  return await fn()
+                }
+                catch (error) {
+                  const status = error.status
+                  const transient = status === undefined || status === 429 || status >= 500
+                  if (!transient || attempt >= 5)
+                    throw error
+                  const wait = Math.min(2000 * 2 ** (attempt - 1), 30000)
+                  core.warning(`${label} failed with a transient error (${error.message}). Retrying in ${wait}ms.`)
+                  await new Promise(resolve => setTimeout(resolve, wait))
+                }
+              }
+            }
+
+            const { owner, repo } = context.repo
+            const issueNumber = Number(process.env.PR_NUMBER)
+            const marker = `<!-- Sticky Pull Request Comment${process.env.STICKY_HEADER} -->`
+            const body = `${readFileSync(process.env.COMMENT_PATH, 'utf8')}\n${marker}`
+
+            const comments = await withRetry('issues.listComments', () =>
+              github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              }),
+            )
+            const existing = comments.find(comment => comment.body?.includes(marker))
+
+            if (!existing) {
+              await withRetry('issues.createComment', () =>
+                github.rest.issues.createComment({ owner, repo, issue_number: issueNumber, body }),
+              )
+              core.info(`Created the package size comment on pull request #${issueNumber}`)
+              return
+            }
+
+            if (existing.body === body) {
+              core.info('The package size comment is unchanged. Skipping the update.')
+              return
+            }
+
+            await withRetry('issues.updateComment', () =>
+              github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body }),
+            )
+            core.info(`Updated the package size comment on pull request #${issueNumber}`)

--- a/.github/workflows/reusable-package-size.yml
+++ b/.github/workflows/reusable-package-size.yml
@@ -27,6 +27,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Retry registry requests instead of failing the job on a transient 5xx.
+  NPM_CONFIG_FETCH_RETRIES: '5'
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '20000'
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+
 jobs:
   analyze:
     runs-on: ${{ inputs.runner }}

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -24,6 +24,12 @@ permissions:
   contents: write
   id-token: write
 
+env:
+  # Retry registry requests instead of failing the job on a transient 5xx.
+  NPM_CONFIG_FETCH_RETRIES: '5'
+  NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '20000'
+  NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+
 jobs:
   release:
     runs-on: ${{ inputs.runner }}
@@ -38,9 +44,23 @@ jobs:
           cache: true
           install: false
 
-      - run: npx changelogithub
+      # A transient GitHub API error here must not abort a release that has
+      # already been tagged.
+      - name: Publish release notes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for attempt in 1 2 3; do
+            if npx changelogithub; then
+              exit 0
+            fi
+            echo "::warning::changelogithub failed on attempt $attempt"
+            if [ "$attempt" -lt 3 ]; then
+              sleep 15
+            fi
+          done
+          echo "::error::changelogithub failed after 3 attempts"
+          exit 1
 
       - run: pnpm install --frozen-lockfile --trust-lockfile
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Two downstream repos hit the same thing this week and both worked around it by copying the reusable workflow into their own repo, which defeats the point of having it here:

- harlan-zw/nuxt-seo-utils#137, the sticky comment step died on `No server is currently available to service your request`
- harlan-zw/nuxt-link-checker#102, the nightly `pkg-pr-new publish` died on a Cloudflare 1101 from pkg.pr.new

Fixed at this layer instead, so every consumer picks it up on `@main` and the two forks can be closed.

`reusable-package-size-comment` no longer uses `marocchino/sticky-pull-request-comment`. It posts through `actions/github-script` with a retry helper: 5xx, 429 and network errors back off and retry, anything else still fails immediately. The marker string is unchanged (`<!-- Sticky Pull Request Comment{header} -->`), so comments already on open PRs get updated in place rather than duplicated. It also paginates the comment list, which the action did not, so a PR past 100 comments stops posting a second sticky comment.

`reusable-nightly` retries the publish 5 times with 30s between attempts, and passes the package list through an env var instead of interpolating `inputs.publish-packages` straight into the shell.

Two more in the same category while I was in here: `reusable-release` retries `changelogithub`, since an API blip there aborts a release that is already tagged and the rerun then has to be done by hand; and all four reusables set `NPM_CONFIG_FETCH_RETRIES` so a registry 5xx retries instead of failing the job.

Also switched this repo's own `nightly.yml` over to the reusable, it had its own copy of the same steps, and applied the same comment fix to `performance-comment.yml`.

I did not add a retry around `pnpm publish` in the release workflow. A retry after a publish that succeeded but timed out just gives you `EPUBLISHCONFLICT`, so it fails either way and the failure is more confusing.

Ran the comment script against stubbed octokit for create, skip-unchanged, update, retry-then-succeed on 503, no-retry on 404, and ignoring another workflow's sticky header.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).