### PR TITLE
feat(shared): detect comark-content as a content provider

### DIFF
--- a/docs/content/2.guides/2.nuxt-content.md
+++ b/docs/content/2.guides/2.nuxt-content.md
@@ -124,6 +124,46 @@ export default defineNuxtConfig({
 })
 ```
 
+## Setup comark-content
+
+[comark-content](https://github.com/harlan-zw/harlan-nuxt/tree/main/packages/comark-content) is a Markdown-only content module. Nuxt SEO supports it first-party.
+
+It needs no schema opt in. Declare the collection and write the frontmatter keys you want.
+
+```ts [content.config.ts]
+import { defineCollection, defineContentConfig } from '@harlan-zw/comark-content'
+
+export default defineContentConfig({
+  collections: {
+    content: defineCollection({
+      type: 'page',
+      source: '**/*.md',
+    }),
+  },
+})
+```
+
+```md [content/about.md]
+---
+title: About
+robots: false
+sitemap:
+  priority: 0.8
+schemaOrg:
+  "@type": "AboutPage"
+---
+
+# About
+```
+
+Three differences from Nuxt Content v3:
+
+- Every page collection is in the sitemap by default. Set `sitemap: false`{lang="ts"} on the collection to opt out.
+- Only Markdown is supported. There are no YAML, JSON, or CSV sources.
+- Nuxt Sitemap names its data source `@harlan-zw/comark-content:urls`, not `@nuxt/content@v3:urls`.
+
+Per-module detail lives in each module's own guide, linked in [Introduction](#introduction).
+
 ## Usage
 
 For the full options available for each module i.e. for the schemas specific to each of the different SEO modules, please see the individual module documentation.

--- a/packages/shared/build.config.ts
+++ b/packages/shared/build.config.ts
@@ -5,6 +5,7 @@ export default defineBuildConfig({
   failOnWarn: false,
   entries: [
     { input: 'src/content', name: 'content' },
+    { input: 'src/content-runtime', name: 'content-runtime' },
     { input: 'src/kit', name: 'kit' },
     { input: 'src/devtools', name: 'devtools' },
     { input: 'src/i18n', name: 'i18n' },
@@ -19,6 +20,7 @@ export default defineBuildConfig({
     /^h3/,
     /^@nuxtjs\/i18n/,
     /^@nuxt\/content/,
+    /^@harlan-zw\/comark-content/,
     /^@nuxt\/schema/,
     /^@nuxt\/devtools-kit/,
     /^@nuxt\/kit/,

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,6 +28,10 @@
       "types": "./dist/content.d.mts",
       "default": "./dist/content.mjs"
     },
+    "./content-runtime": {
+      "types": "./dist/content-runtime.d.mts",
+      "default": "./dist/content-runtime.mjs"
+    },
     "./kit": {
       "types": "./dist/kit.d.mts",
       "default": "./dist/kit.mjs"
@@ -110,6 +114,8 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "catalog:",
+    "@harlan-zw/comark-content": "catalog:",
+    "@nuxt/content": "catalog:",
     "@nuxt/module-builder": "catalog:",
     "@nuxt/schema": "catalog:",
     "@nuxt/test-utils": "catalog:",

--- a/packages/shared/src/content-runtime.ts
+++ b/packages/shared/src/content-runtime.ts
@@ -1,0 +1,45 @@
+/**
+ * Contract for `#nuxtseo/content`, the per-provider runtime shim that
+ * `setupContentRuntime()` aliases into the Nitro bundle.
+ *
+ * `@nuxt/content` and `comark-content` cannot both be imported by one build:
+ * pulling `@nuxt/content/server` into an app that does not have it fails the
+ * bundle. So provider choice is a build-time alias, and every consumer imports
+ * this one specifier instead of naming a package.
+ */
+
+export type ContentRuntimeProvider = 'nuxt-content-v3' | 'comark' | 'none'
+
+/**
+ * A queryable page collection, normalized across providers.
+ *
+ * The two manifests disagree in shape. `@nuxt/content` keys an object by name and
+ * carries a schema-derived `fields` map. comark returns an array and carries a
+ * per-collection sitemap flag. Both reduce to this.
+ */
+export interface PageCollection {
+  name: string
+  /**
+   * Whether the collection declares `field`.
+   *
+   * For `@nuxt/content` this is the schema opt in, so a module can require its own
+   * field before claiming the collection. comark derives no field list from a
+   * schema, so it answers `true` and relies on frontmatter being present or absent.
+   */
+  hasField: (field: string) => boolean
+  /** `false` only when the collection opted out of the sitemap. */
+  inSitemap: boolean
+}
+
+export interface ContentPageQuery {
+  where: (field: string, operator: string, value?: unknown) => ContentPageQuery
+  select: (...fields: string[]) => ContentPageQuery
+  all: () => Promise<Record<string, any>[]>
+  first: () => Promise<Record<string, any> | null>
+}
+
+export interface ContentRuntime {
+  provider: ContentRuntimeProvider
+  listPageCollections: (event: unknown) => Promise<PageCollection[]>
+  queryPages: (event: unknown, collection: string) => ContentPageQuery
+}

--- a/packages/shared/src/kit.ts
+++ b/packages/shared/src/kit.ts
@@ -248,3 +248,69 @@ export async function resolveHostUnheadMajor(rootDir: string): Promise<UnheadMaj
   }
   return 3
 }
+
+export const COMARK_CONTENT_MODULE = '@harlan-zw/comark-content'
+
+/**
+ * The lowest comark-content that exposes `queryCollectionManifest` from
+ * `@harlan-zw/comark-content/server`. Every integration here walks collections
+ * through that manifest, so an older build has no first-party path.
+ */
+const COMARK_CONTENT_MINIMUM = [0, 1, 2] as const
+
+/**
+ * The Markdown content module backing this app, if any.
+ *
+ * `@nuxt/content` and `comark-content` both fire the `content:file:beforeParse`
+ * and `content:file:afterParse` build hooks with the same context shape, so a
+ * module's frontmatter handling is written once. They differ at runtime:
+ * `@nuxt/content` queries a SQL database, comark reads Nitro server assets.
+ */
+export type ContentProvider
+  = | { _tag: 'None' }
+    | { _tag: 'NuxtContent', version: 2 | 3 }
+    | { _tag: 'Comark' }
+
+/**
+ * comark declares no `version` in its module meta, so
+ * `hasNuxtModuleCompatibility` reports false for every release. Read the
+ * installed package instead.
+ */
+async function comarkSatisfiesMinimum(nuxt: Nuxt): Promise<boolean> {
+  const pkg = await readPackageJSON(COMARK_CONTENT_MODULE, { url: normalizePackageUrl(nuxt.options.rootDir) }).catch(() => {
+    // Registered as a module but not resolvable from the app. Treat it as absent
+    // rather than failing the build; the integration is optional either way.
+    return null
+  })
+  const parts = pkg?.version?.split('.').map(part => Number.parseInt(part, 10))
+  if (!parts || parts.length < 3 || parts.some(part => !Number.isFinite(part)))
+    return false
+  for (const [index, minimum] of COMARK_CONTENT_MINIMUM.entries()) {
+    if (parts[index]! !== minimum)
+      return parts[index]! > minimum
+  }
+  return true
+}
+
+/**
+ * Detect which Markdown content module is installed.
+ *
+ * `@nuxt/content` wins when both are present: it owns the `content` config key
+ * and its runtime is the one the app's pages query.
+ */
+export async function resolveContentProvider(nuxt: Nuxt = useNuxt()): Promise<ContentProvider> {
+  const nuxtContent = await resolveNuxtContentVersion()
+  if (nuxtContent)
+    return { _tag: 'NuxtContent', version: nuxtContent.version }
+  if (hasNuxtModule(COMARK_CONTENT_MODULE, nuxt) && await comarkSatisfiesMinimum(nuxt))
+    return { _tag: 'Comark' }
+  return { _tag: 'None' }
+}
+
+/**
+ * Whether the provider fires the `content:file:*` build hooks, which is where
+ * every module maps its frontmatter field onto the parsed page.
+ */
+export function hasContentFileHooks(provider: ContentProvider): boolean {
+  return provider._tag === 'Comark' || (provider._tag === 'NuxtContent' && provider.version === 3)
+}

--- a/packages/shared/src/kit.ts
+++ b/packages/shared/src/kit.ts
@@ -314,3 +314,35 @@ export async function resolveContentProvider(nuxt: Nuxt = useNuxt()): Promise<Co
 export function hasContentFileHooks(provider: ContentProvider): boolean {
   return provider._tag === 'Comark' || (provider._tag === 'NuxtContent' && provider.version === 3)
 }
+
+/**
+ * Alias `#nuxtseo/content` to the shim for the detected provider.
+ *
+ * Consumers import collection enumeration and page queries from that one
+ * specifier instead of naming `@nuxt/content/server` or
+ * `@harlan-zw/comark-content/server`. Naming a package directly would put it in
+ * every build, and a build without that package installed fails to bundle.
+ *
+ * Nuxt Content v2 has no collection model, so it resolves to the empty shim.
+ * A module that supports v2 keeps its own v2 path.
+ */
+export function setupContentRuntime(provider: ContentProvider, nuxt: Nuxt = useNuxt()): void {
+  const shim = provider._tag === 'Comark'
+    ? 'comark'
+    : provider._tag === 'NuxtContent' && provider.version === 3
+      ? 'nuxt-content-v3'
+      : 'none'
+  const resolver = createResolver(import.meta.url)
+  // This package does not depend on nitro's option types, so narrow the two fields
+  // it touches rather than pulling the whole NitroConfig augmentation in.
+  const nitro = (nuxt.options as { nitro?: { alias?: Record<string, string>, externals?: { inline?: string[] } } }).nitro ??= {}
+  nitro.alias ??= {}
+  nitro.alias['#nuxtseo/content'] = resolver.resolve(`./runtime/content/${shim}`)
+  // The shim ships inside this package, so Nitro treats it as an external dependency
+  // and leaves its `@nuxt/content/server` import for Node to resolve at runtime.
+  // `#content/manifest` is a build-time alias, so that import then fails to load.
+  // Inline the shim directory to get it bundled with the aliases applied.
+  nitro.externals ??= {}
+  nitro.externals.inline ??= []
+  nitro.externals.inline.push(resolver.resolve('./runtime/content/'))
+}

--- a/packages/shared/src/runtime/content/comark.ts
+++ b/packages/shared/src/runtime/content/comark.ts
@@ -1,0 +1,55 @@
+import type { ContentPageQuery, ContentRuntimeProvider, PageCollection } from '../../content-runtime'
+import { queryCollection, queryCollectionManifest } from '@harlan-zw/comark-content/server'
+
+export const provider: ContentRuntimeProvider = 'comark'
+
+export async function listPageCollections(event: unknown): Promise<PageCollection[]> {
+  const manifest = await queryCollectionManifest(event)
+  return manifest.map(entry => ({
+    name: entry.name,
+    // comark derives no field list from a schema, so every field is available to ask
+    // for. A collection opts out of the sitemap on the collection itself.
+    hasField: () => true,
+    inSitemap: entry.sitemap,
+  }))
+}
+
+/**
+ * comark's query builder gained `IS NOT NULL` in 0.1.4. Translate it into a
+ * post-filter so one caller works against every supported comark.
+ *
+ * Every operation is buffered rather than forwarded on call, so the caller can
+ * order `where` and `select` however it likes: a post-filtered field has to survive
+ * the projection to be readable, and that is only known once the chain ends.
+ */
+export function queryPages(event: unknown, collection: string): ContentPageQuery {
+  const wheres: [string, string, unknown][] = []
+  let selected: string[] | undefined
+
+  const query: ContentPageQuery = {
+    where(field, operator, value) {
+      wheres.push([field, operator, value])
+      return query
+    },
+    select(...fields) {
+      selected = fields
+      return query
+    },
+    async all() {
+      const notNull = wheres.filter(([, operator]) => operator === 'IS NOT NULL').map(([field]) => field)
+      const builder = queryCollection(event, collection)
+      for (const [field, operator, value] of wheres) {
+        if (operator !== 'IS NOT NULL')
+          builder.where(field, operator as Parameters<typeof builder.where>[1], value)
+      }
+      if (selected)
+        builder.select(...new Set([...selected, ...notNull]))
+      const rows = await builder.all() as Record<string, any>[]
+      return rows.filter(row => notNull.every(field => row[field] !== null && row[field] !== undefined))
+    },
+    async first() {
+      return (await query.all())[0] ?? null
+    },
+  }
+  return query
+}

--- a/packages/shared/src/runtime/content/none.ts
+++ b/packages/shared/src/runtime/content/none.ts
@@ -1,0 +1,15 @@
+import type { ContentPageQuery, ContentRuntimeProvider, PageCollection } from '../../content-runtime'
+
+export const provider: ContentRuntimeProvider = 'none'
+
+export async function listPageCollections(_event: unknown): Promise<PageCollection[]> {
+  return []
+}
+
+/**
+ * Never reached: every caller enumerates collections first and gets none.
+ * Present so the specifier resolves and consumers import it unconditionally.
+ */
+export function queryPages(_event: unknown, collection: string): ContentPageQuery {
+  throw new Error(`No content module is installed, so collection "${collection}" cannot be queried.`)
+}

--- a/packages/shared/src/runtime/content/nuxt-content-v3.ts
+++ b/packages/shared/src/runtime/content/nuxt-content-v3.ts
@@ -1,0 +1,21 @@
+import type { ContentPageQuery, ContentRuntimeProvider, PageCollection } from '../../content-runtime'
+import { queryCollection } from '@nuxt/content/server'
+// @ts-expect-error virtual module provided by @nuxt/content
+import manifest from '#content/manifest'
+
+export const provider: ContentRuntimeProvider = 'nuxt-content-v3'
+
+export async function listPageCollections(_event: unknown): Promise<PageCollection[]> {
+  return Object.entries(manifest as Record<string, { fields?: Record<string, unknown> }>)
+    .map(([name, entry]) => ({
+      name,
+      hasField: (field: string) => !!entry.fields && field in entry.fields,
+      // @nuxt/content has no collection level sitemap opt out. The schema field is
+      // the opt in, which `hasField` answers.
+      inSitemap: true,
+    }))
+}
+
+export function queryPages(event: unknown, collection: string): ContentPageQuery {
+  return queryCollection(event as never, collection as never) as unknown as ContentPageQuery
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@clack/prompts':
       specifier: ^1.7.0
       version: 1.7.0
+    '@harlan-zw/comark-content':
+      specifier: ^0.1.3
+      version: 0.1.3
     '@iconify-json/carbon':
       specifier: ^1.2.25
       version: 1.2.25
@@ -445,6 +448,12 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 'catalog:'
         version: 0.18.5
+      '@harlan-zw/comark-content':
+        specifier: 'catalog:'
+        version: 0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(609add390b70131cc50ac2b1385af5f6))(oxc-parser@0.142.0)(rolldown@1.2.3)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
+      '@nuxt/content':
+        specifier: 'catalog:'
+        version: 3.15.2(@oxc-project/types@0.143.0)(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1))(esbuild@0.28.0)(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       '@nuxt/module-builder':
         specifier: 'catalog:'
         version: 1.0.3(@nuxt/cli@3.37.0(@nuxt/schema@4.5.2)(cac@6.7.14)(magicast@0.5.4)(supports-color@10.2.2))(@volar/typescript@2.4.28(typescript@6.0.3))(@vue/compiler-core@3.5.41)(@vue/language-core@3.3.9)(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-tsc@3.3.9(typescript@6.0.3))(vue@3.5.41(typescript@6.0.3))
@@ -456,16 +465,16 @@ importers:
         version: 4.1.0(@vue/test-utils@2.4.11(@vue/compiler-dom@3.5.41)(@vue/server-renderer@3.5.41)(vue@3.5.41(typescript@6.0.3)))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.0)(happy-dom@20.11.2)(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vitest@4.1.10(@types/node@26.0.0)(happy-dom@20.11.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))
       '@nuxtjs/i18n':
         specifier: 'catalog:'
-        version: 10.6.0(@vue/compiler-dom@3.5.41)(db0@0.3.4(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(better-sqlite3@13.0.3)))(esbuild@0.28.0)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 10.6.0(@vue/compiler-dom@3.5.41)(db0@0.3.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1)))(esbuild@0.28.0)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       h3:
         specifier: 'catalog:'
         version: 1.15.11
       nitropack:
         specifier: 'catalog:'
-        version: 2.13.4(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(better-sqlite3@13.0.3))(oxc-parser@0.142.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 2.13.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1))(oxc-parser@0.142.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
       nuxt:
         specifier: 'catalog:'
-        version: 4.5.2(b34ba6d0a0918491f2e5cbad17848d2d)
+        version: 4.5.2(609add390b70131cc50ac2b1385af5f6)
       nuxt-site-config:
         specifier: 'catalog:'
         version: 4.2.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
@@ -1444,6 +1453,13 @@ packages:
 
   '@floating-ui/vue@1.1.11':
     resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
+
+  '@harlan-zw/comark-content@0.1.3':
+    resolution: {integrity: sha512-nmGSQjp8lqLHFenlKXg/7mB8p82Gw0spp8Jr3aSvaHpyxQwqS3enDE+IxrnouH15bCjRQeZab+v7uWDWPWpNGA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      nuxt: '>=4.5.0 <5.0.0'
+      vue: '>=3.5.0 <4.0.0'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -3882,8 +3898,14 @@ packages:
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4806,6 +4828,23 @@ packages:
   colortranslator@5.0.0:
     resolution: {integrity: sha512-Z3UPUKasUVDFCDYAjP2fmlVRf1jFHJv1izAmPjiOa0OCIw1W7iC8PZ2GsoDa8uZv+mKyWopxxStT9q05+27h7w==}
 
+  comark@0.6.2:
+    resolution: {integrity: sha512-hlWa7KlGPfRxovQavnHZlLlTUKrfwE7/o4ewCY0FzqFtRvVT8VdslrumQwELIiK9utsurpoSWCBFj1yVMtDOtw==}
+    peerDependencies:
+      beautiful-mermaid: ^1.1.3
+      katex: ^0.17.0
+      rangi: ^2.2.0
+      shiki: ^4.3.1
+    peerDependenciesMeta:
+      beautiful-mermaid:
+        optional: true
+      katex:
+        optional: true
+      rangi:
+        optional: true
+      shiki:
+        optional: true
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -5117,15 +5156,31 @@ packages:
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
 
+  dom-serializer@3.1.1:
+    resolution: {integrity: sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==}
+    engines: {node: '>=20.19.0'}
+
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domelementtype@3.0.0:
+    resolution: {integrity: sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==}
+    engines: {node: '>=20.19.0'}
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  domhandler@6.0.1:
+    resolution: {integrity: sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==}
+    engines: {node: '>=20.19.0'}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  domutils@4.0.2:
+    resolution: {integrity: sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==}
+    engines: {node: '>=20.19.0'}
 
   dot-prop@10.1.0:
     resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
@@ -6100,6 +6155,10 @@ packages:
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
+  htmlparser2@12.0.0:
+    resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
+    engines: {node: '>=20.19.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -6382,6 +6441,10 @@ packages:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
     hasBin: true
 
+  js-yaml@5.3.0:
+    resolution: {integrity: sha512-muutsYr+e2+d3rTgUGslq5rxbBlUy3cJ61IsHag2QNDQV+7zXWjkUpmALIajhrlLlrgRUiymj6U3zUr/TMK84Q==}
+    hasBin: true
+
   jsdoc-type-pratt-parser@7.2.0:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
     engines: {node: '>=20.0.0'}
@@ -6619,6 +6682,9 @@ packages:
   linebreak@1.1.0:
     resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
 
@@ -6693,6 +6759,9 @@ packages:
   make-asynchronous@1.1.0:
     resolution: {integrity: sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==}
     engines: {node: '>=18'}
+
+  markdown-exit@1.1.0-beta.2:
+    resolution: {integrity: sha512-8CzMGVlFZ4DEfnc8KU+4ycUW2SIOuiXqCHD7z51ecVEi/weyc0f2ylQbCm4KoKuVlTZSuMUMnWT0hTyquZ7anQ==}
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
@@ -6774,6 +6843,9 @@ packages:
   mdream@1.5.12:
     resolution: {integrity: sha512-9d+Bq09UUe3fQa0QTfRD2e3djGqA4rTbesn2hEDXg6blRjZBfRcLEgEwt2FvfiFb/QJlIP+LJzIZ6UxFfa5Y5Q==}
     hasBin: true
+
+  mdurl@2.1.0:
+    resolution: {integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -7928,6 +8000,10 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -7951,6 +8027,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rangi@2.2.0:
+    resolution: {integrity: sha512-zMXLNs+3ejB2dg5kjJdNbllNq6FrdtEbHA9f3POxbSIHb0CyslALbY8qSDCE2r+/6Ku7xaVHKtnC5qHbF2SgNg==}
+    hasBin: true
 
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
@@ -8667,6 +8747,9 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
@@ -10318,6 +10401,23 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
+  '@harlan-zw/comark-content@0.1.3(magic-string@1.1.0)(magicast@0.5.4)(nuxt@4.5.2(609add390b70131cc50ac2b1385af5f6))(oxc-parser@0.142.0)(rolldown@1.2.3)(shiki@4.4.2)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))
+      comark: 0.6.2(rangi@2.2.0)(shiki@4.4.2)
+      nuxt: 4.5.2(609add390b70131cc50ac2b1385af5f6)
+      rangi: 2.2.0
+      vue: 3.5.41(typescript@6.0.3)
+    transitivePeerDependencies:
+      - beautiful-mermaid
+      - katex
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - shiki
+      - unplugin
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -10930,7 +11030,6 @@ snapshots:
       - utf-8-validate
       - vite
       - webpack
-    optional: true
 
   '@nuxt/content@3.15.2(@oxc-project/types@0.143.0)(@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3)))(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(better-sqlite3@13.0.3))(esbuild@0.28.0)(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(valibot@1.4.2(typescript@6.0.3))(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
@@ -11569,7 +11668,6 @@ snapshots:
       - oxc-parser
       - rolldown
       - unplugin
-    optional: true
 
   '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))':
     dependencies:
@@ -12667,6 +12765,76 @@ snapshots:
       - vue
       - webpack
 
+  '@nuxtjs/i18n@10.6.0(@vue/compiler-dom@3.5.41)(db0@0.3.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1)))(esbuild@0.28.0)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
+    dependencies:
+      '@intlify/core': 11.4.8
+      '@intlify/h3': 0.7.4
+      '@intlify/message-compiler': 11.4.8
+      '@intlify/shared': 11.4.8
+      '@intlify/unplugin-vue-i18n': 11.2.4(@vue/compiler-dom@3.5.41)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue-i18n@11.4.8(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
+      '@intlify/utils': 0.14.1
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.62.2)
+      '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.62.2)
+      '@vue/compiler-sfc': 3.5.40
+      confbox: 0.2.4
+      defu: 6.1.7
+      devalue: 5.9.0
+      h3: 1.15.11
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nuxt-define: 1.0.0
+      oxc-parser: 0.141.0
+      oxc-transform: 0.141.0
+      oxc-walker: 0.7.0(oxc-parser@0.141.0)
+      pathe: 2.0.3
+      ufo: 1.6.4
+      unhead: 3.2.3(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      unplugin: 3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      unrouting: 0.2.2
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@12.11.1)(drizzle-orm@0.45.2(better-sqlite3@12.11.1)))(ioredis@5.11.1(supports-color@10.2.2))
+      vue-i18n: 11.4.8(vue@3.5.41(typescript@6.0.3))
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.40)(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@farmfe/core'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vue/compiler-dom'
+      - aws4fetch
+      - bun-types-no-globals
+      - db0
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - magicast
+      - petite-vue-i18n
+      - pinia
+      - rolldown
+      - rollup
+      - supports-color
+      - typescript
+      - unloader
+      - uploadthing
+      - vite
+      - vue
+      - webpack
+
   '@nuxtjs/i18n@10.6.0(@vue/compiler-dom@3.5.41)(db0@0.3.4(better-sqlite3@13.0.3)(drizzle-orm@0.45.2(better-sqlite3@13.0.3)))(esbuild@0.28.0)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.2)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@intlify/core': 11.4.8
@@ -12844,7 +13012,6 @@ snapshots:
       - rolldown
       - supports-color
       - unplugin
-    optional: true
 
   '@nuxtjs/robots@6.1.4(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.3)(rollup@4.62.2)(vite@8.2.0(@types/node@26.0.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))(zod@4.4.3)':
     dependencies:
@@ -14034,9 +14201,13 @@ snapshots:
 
   '@types/katex@0.16.8': {}
 
+  '@types/linkify-it@5.0.0': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 
@@ -15245,6 +15416,16 @@ snapshots:
 
   colortranslator@5.0.0: {}
 
+  comark@0.6.2(rangi@2.2.0)(shiki@4.4.2):
+    dependencies:
+      entities: 8.0.0
+      htmlparser2: 12.0.0
+      js-yaml: 5.3.0
+      markdown-exit: 1.1.0-beta.2
+    optionalDependencies:
+      rangi: 2.2.0
+      shiki: 4.4.2
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -15576,17 +15757,35 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
+  dom-serializer@3.1.1:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      entities: 8.0.0
+
   domelementtype@2.3.0: {}
+
+  domelementtype@3.0.0: {}
 
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  domhandler@6.0.1:
+    dependencies:
+      domelementtype: 3.0.0
 
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  domutils@4.0.2:
+    dependencies:
+      dom-serializer: 3.1.1
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
 
   dot-prop@10.1.0:
     dependencies:
@@ -16764,6 +16963,13 @@ snapshots:
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
 
+  htmlparser2@12.0.0:
+    dependencies:
+      domelementtype: 3.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      entities: 8.0.0
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -17042,6 +17248,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  js-yaml@5.3.0:
+    dependencies:
+      argparse: 2.0.1
+
   jsdoc-type-pratt-parser@7.2.0: {}
 
   jsdoc-type-pratt-parser@8.0.0: {}
@@ -17224,6 +17434,10 @@ snapshots:
       base64-js: 0.0.8
       unicode-trie: 2.0.0
 
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
   linkifyjs@4.3.3: {}
 
   lint-staged@17.3.0:
@@ -17368,6 +17582,16 @@ snapshots:
       p-event: 6.0.1
       type-fest: 4.41.0
       web-worker: 1.5.0
+
+  markdown-exit@1.1.0-beta.2:
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+      entities: 7.0.1
+      linkify-it: 5.0.2
+      mdurl: 2.1.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -17548,6 +17772,8 @@ snapshots:
       '@mdream/rust-wasm32-wasi': 1.5.12
       '@mdream/rust-win32-arm64-msvc': 1.5.12
       '@mdream/rust-win32-x64-msvc': 1.5.12
+
+  mdurl@2.1.0: {}
 
   merge-stream@2.0.0: {}
 
@@ -18390,7 +18616,6 @@ snapshots:
       - '@oxc-project/types'
       - magicast
       - rolldown
-    optional: true
 
   nuxt-define@1.0.0: {}
 
@@ -19973,6 +20198,8 @@ snapshots:
       once: 1.4.0
     optional: true
 
+  punycode.js@2.3.1: {}
+
   punycode@2.3.1: {}
 
   quansync@0.2.11: {}
@@ -19986,6 +20213,8 @@ snapshots:
   radix3@1.1.2: {}
 
   range-parser@1.2.1: {}
+
+  rangi@2.2.0: {}
 
   rc9@3.0.1:
     dependencies:
@@ -20878,6 +21107,8 @@ snapshots:
   typescript@5.9.3: {}
 
   typescript@6.0.3: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ minimumReleaseAgeExclude:
   - '@unhead/vue@3.2.1'
   - '@mdream/rust-wasm32-wasi@1.5.12'
   - eslint-plugin-harlanzw@0.19.1
+  - '@harlan-zw/comark-content@0.1.3'
 # pnpm 11 reads these from pnpm-workspace.yaml, not .npmrc.
 # @nuxtjs/i18n resolves its private @intlify/* + vue-i18n deps via @nuxt/kit's
 # resolveModule, which only searches root node_modules, so hoist just those
@@ -95,6 +96,7 @@ catalog:
   '@clack/prompts': ^1.7.0
   '@iconify-json/carbon': ^1.2.25
   '@jridgewell/trace-mapping': ^0.3.31
+  '@harlan-zw/comark-content': ^0.1.3
   '@nuxt/content': ^3.15.2
   '@nuxt/devtools-kit': 4.0.0-alpha.7
   '@nuxt/fonts': ^0.14.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ minimumReleaseAgeExclude:
   - '@img/sharp-win32-arm64@0.35.0'
   - '@img/sharp-win32-ia32@0.35.0'
   - '@img/sharp-win32-x64@0.35.0'
-  - '@nuxtjs/robots@6.1.0 || 6.1.3'
+  - '@nuxtjs/robots@6.1.0 || 6.1.3 || 6.1.5'
   - '@nuxtjs/sitemap@8.2.0 || 8.2.3 || 8.3.0'
   - nuxt-ai-ready@1.4.0
   - nuxt-link-checker@5.1.0 || 5.1.3
@@ -94,9 +94,9 @@ catalog:
   '@antfu/eslint-config': ^9.3.0
   '@arethetypeswrong/cli': ^0.18.5
   '@clack/prompts': ^1.7.0
+  '@harlan-zw/comark-content': ^0.1.3
   '@iconify-json/carbon': ^1.2.25
   '@jridgewell/trace-mapping': ^0.3.31
-  '@harlan-zw/comark-content': ^0.1.3
   '@nuxt/content': ^3.15.2
   '@nuxt/devtools-kit': 4.0.0-alpha.7
   '@nuxt/fonts': ^0.14.0
@@ -106,7 +106,7 @@ catalog:
   '@nuxt/test-utils': ^4.1.0
   '@nuxt/ui': ^4.10.0
   '@nuxtjs/i18n': ^10.6.0
-  '@nuxtjs/robots': ^6.1.4
+  '@nuxtjs/robots': ^6.1.5
   '@nuxtjs/sitemap': ^8.3.3
   '@resvg/resvg-js': ^2.6.2
   '@shikijs/langs': ^4.4.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ minimumReleaseAgeExclude:
   - '@img/sharp-win32-arm64@0.35.0'
   - '@img/sharp-win32-ia32@0.35.0'
   - '@img/sharp-win32-x64@0.35.0'
-  - '@nuxtjs/robots@6.1.0 || 6.1.3 || 6.1.5'
+  - '@nuxtjs/robots@6.1.0 || 6.1.3'
   - '@nuxtjs/sitemap@8.2.0 || 8.2.3 || 8.3.0'
   - nuxt-ai-ready@1.4.0
   - nuxt-link-checker@5.1.0 || 5.1.3
@@ -106,7 +106,7 @@ catalog:
   '@nuxt/test-utils': ^4.1.0
   '@nuxt/ui': ^4.10.0
   '@nuxtjs/i18n': ^10.6.0
-  '@nuxtjs/robots': ^6.1.5
+  '@nuxtjs/robots': ^6.1.4
   '@nuxtjs/sitemap': ^8.3.3
   '@resvg/resvg-js': ^2.6.2
   '@shikijs/langs': ^4.4.2


### PR DESCRIPTION
### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Every content integration in the ecosystem gates on `resolveNuxtContentVersion()`, which is `hasNuxtModule('@nuxt/content')` and nothing else. An app running [comark-content](https://github.com/harlan-zw/harlan-nuxt/tree/main/packages/comark-content) falls through all of them: no robots frontmatter, no sitemap source, no schema.org injection, no link sources. Everything looks installed and quietly does nothing.

`resolveContentProvider()` replaces that check with a tagged union:

```ts
type ContentProvider
  = | { _tag: 'None' }
    | { _tag: 'NuxtContent', version: 2 | 3 }
    | { _tag: 'Comark' }
```

`@nuxt/content` wins when both are present, since it owns the `content` config key and its runtime is what the app's pages query.

comark declares no `version` in its module meta, so `hasNuxtModuleCompatibility` reports false for every release of it. The minimum-version check reads the installed `package.json` instead. nuxt-ai-ready already worked around this the same way and I lifted the approach from there rather than inventing a second one.

The other export is `hasContentFileHooks(provider)`. Both `@nuxt/content` v3 and comark fire `content:file:beforeParse` and `content:file:afterParse` with the same context shape, so a module writes its frontmatter mapping once and gates it on that rather than on a version number.

`resolveNuxtContentVersion()` stays exported. Nothing that used it had to change.

First of six PRs. The five downstream modules import `resolveContentProvider` from `nuxtseo-shared`, so their CI stays red until this ships.


### 🔗 Related

Six PRs for one cross-repo change. Release order is top to bottom:

1. nuxt-seo `nuxtseo-shared` https://github.com/harlan-zw/nuxt-seo/pull/621
2. `@nuxtjs/sitemap` https://github.com/nuxt-modules/sitemap/pull/665
3. `@nuxtjs/robots` https://github.com/nuxt-modules/robots/pull/321
4. `nuxt-schema-org` https://github.com/harlan-zw/nuxt-schema-org/pull/151
5. `nuxt-link-checker` https://github.com/harlan-zw/nuxt-link-checker/pull/104
6. `comark-content` https://github.com/harlan-zw/harlan-nuxt/pull/74

2 through 5 need 1 published. 6 needs 2 published.

## Second commit: the `#nuxtseo/content` runtime adapter

Detection being shared was only half of it. Every consumer still named `@nuxt/content/server` or `@harlan-zw/comark-content/server` directly and walked the manifest itself, so sitemap and link-checker each carried two near-identical runtime files. Rename comark and that is a sweep across six repos.

`setupContentRuntime(provider)` aliases `#nuxtseo/content` to one shim per provider. It has to be an alias, not a runtime branch: importing `@nuxt/content/server` in an app without it fails the bundle.

The contract is deliberately small, because the two providers diverge for real reasons and a full query abstraction would paper over that:

```ts
provider: 'nuxt-content-v3' | 'comark' | 'none'
listPageCollections(event): Promise<PageCollection[]>
queryPages(event, collection): ContentPageQuery
interface PageCollection { name, hasField(f), inSitemap }
```

`hasField` and `inSitemap` are where the manifests reconcile. `@nuxt/content` keys an object by name with a schema-derived `fields` map and has no collection-level sitemap opt out. comark returns an array with a per-collection sitemap flag and derives no field list. Each answers the other trivially.

The comark shim also translates `IS NOT NULL` into a post-filter, so one caller works against comark 0.1.2 up rather than requiring the version that added the operator natively.

One thing that cost me a debugging round and is worth knowing if you touch this: the shims ship inside this package, so Nitro externalizes them and leaves `@nuxt/content/server` for Node to resolve at runtime, where the `#content/manifest` build alias no longer exists. Every v3 fixture failed with `Package import specifier "#content/manifest" is not defined`. Fix is `nitro.externals.inline` on the shim directory. Feels like something Nitro could handle better for module-adjacent runtime code shipped from a dependency, but inlining is the honest workaround.

Nuxt Content v2 has no collection model, so it resolves to the empty shim and any module supporting v2 keeps its own v2 path. That is the one place the abstraction genuinely does not reach.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
