### PR TITLE
fix(shared): bundle shared runtime in server output

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -48,6 +48,7 @@ jobs:
           cp -R "$FIXTURE_SOURCE/." packages/nuxt-seo/test/fixtures/performance/
           pnpm install --frozen-lockfile --trust-lockfile
           pnpm dev:prepare
+          pnpm --dir packages/shared build
           pnpm --filter @nuxtjs/seo exec nuxi build test/fixtures/performance
 
       - name: Warn when the base build is unavailable

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "pnpm --filter './packages/*' build",
     "benchmark": "node bench/performance/run.mjs --server packages/nuxt-seo/test/fixtures/performance/.output/server/index.mjs --output bench/performance/result.json --profiles bench/performance/profiles",
-    "benchmark:build": "pnpm --filter @nuxtjs/seo exec nuxi build test/fixtures/performance",
+    "benchmark:build": "pnpm --dir packages/shared build && pnpm --filter @nuxtjs/seo exec nuxi build test/fixtures/performance",
     "benchmark:test": "node --test bench/performance/*.test.mjs",
     "dev": "pnpm --filter @nuxtjs/seo dev",
     "dev:prepare": "pnpm --filter './packages/**' stub && pnpm --filter @nuxtjs/seo dev:prepare",

--- a/packages/shared/src/nitro-compatibility.ts
+++ b/packages/shared/src/nitro-compatibility.ts
@@ -35,6 +35,9 @@ const runtimeSetupMarker = Symbol.for('nuxtseo:nitro-runtime-compatibility:reque
 
 interface NuxtNitroCompatibilityOptions {
   alias?: Record<string, string>
+  externals?: {
+    inline?: (string | RegExp)[]
+  }
   typescript?: {
     tsConfig?: {
       compilerOptions?: {
@@ -196,7 +199,12 @@ function applyNitroRuntimeCompatibility(
   const nuxtOptions = nuxt.options as Nuxt['options'] & { nitro?: NuxtNitroCompatibilityOptions }
   const nitroOptions = nuxtOptions.nitro ||= {}
   nitroOptions.alias ||= {}
+  nitroOptions.externals ||= {}
+  nitroOptions.externals.inline ||= []
   nitroOptions.virtual ||= {}
+  // Vercel can omit traced shared subpaths from deployed functions: https://github.com/harlan-zw/nuxt-seo/issues/623
+  if (!nitroOptions.externals.inline.includes('nuxtseo-shared'))
+    nitroOptions.externals.inline.push('nuxtseo-shared')
   const h3RuntimeModule = compatibility._tag === 'nitro-v3' ? 'nitro/h3' : 'h3'
   nitroOptions.alias[H3_RUNTIME_MODULE] = h3RuntimeModule
   const h3Resolution = resolveRuntimeModule(nuxt, h3RuntimeModule)

--- a/packages/shared/test/unit/nitro.test.ts
+++ b/packages/shared/test/unit/nitro.test.ts
@@ -150,7 +150,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     )
   })
 
-  it('registers shared templates once when several modules call setup', () => {
+  it('registers shared compatibility once when several modules call setup', () => {
     getNuxtVersionMock.mockReturnValue('4.5.1')
     const nuxt = createNuxt()
 
@@ -158,6 +158,7 @@ describe('setupNitroRuntimeCompatibility', () => {
     setupNitroRuntimeCompatibility(nuxt)
 
     expect(addTypeTemplateMock).toHaveBeenCalledOnce()
+    expect(nuxt.options.nitro.externals?.inline).toEqual(['nuxtseo-shared'])
   })
 
   it('registers the request context type bridge after an older helper ran', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #623

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Vercel output tracing could omit `nuxtseo-shared` subpaths, leaving server functions importing a missing `dist/utils.mjs`. Nitro now bundles the shared runtime into server output.

> 🤖 AI disclosure: [Harlan Agent Kit](https://github.com/harlan-zw/harlan-agent-kit) modified this description. [My AI open-source policy](https://harlanzw.com/blog/ai-in-open-source).
